### PR TITLE
Close #7 Implement core module (Pure Java / JDK only)

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -3,3 +3,10 @@ plugins {
     id("publish-plugin")
     id("spotless-java")
 }
+
+dependencies {
+    implementation(libs.jspecify)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.junit.jupiter)
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/annotation/EndpointGate.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/annotation/EndpointGate.java
@@ -1,0 +1,61 @@
+package net.brightroom.endpointgate.core.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Endpoint gate annotation to control access to specific endpoints. This annotation can be applied
+ * at both method and class levels to manage endpoint availability.
+ *
+ * <p>Condition expressions and rollout percentages are configured via {@code
+ * endpoint-gate.gates.<name>} in {@code application.yaml} rather than on the annotation itself.
+ *
+ * <p>Usage examples:
+ *
+ * <pre>{@code
+ * // Method level
+ * {@literal @}EndpointGate("new-api")
+ * public void newFeature() {
+ *     // This method will only be accessible if "new-api" gate is enabled
+ * }
+ *
+ * // Class level
+ * {@literal @}EndpointGate("beta-features")
+ * public class BetaController {
+ *     // All methods in this class will only be accessible if "beta-features" is enabled
+ * }
+ * }</pre>
+ *
+ * <p>To configure a condition or rollout percentage, use {@code application.yaml}:
+ *
+ * <pre>{@code
+ * endpoint-gate:
+ *   gates:
+ *     new-api:
+ *       enabled: true
+ *       condition: "headers['X-Beta'] != null"
+ *       rollout: 50
+ * }</pre>
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface EndpointGate {
+
+  /**
+   * Specifies the gate associated with a method or class. The value represents the unique
+   * identifier of the gate that determines whether the annotated method or class is accessible or
+   * enabled.
+   *
+   * <p>This element is required. {@code @EndpointGate} without a value will result in a
+   * compile-time error. An explicit empty string (e.g., {@code @EndpointGate("")}) is also not
+   * permitted and will cause an {@link IllegalStateException} to be thrown at request time by the
+   * interceptor.
+   *
+   * @return the identifier of the gate; must be a non-empty string
+   */
+  String value();
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/condition/ConditionVariables.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/condition/ConditionVariables.java
@@ -1,0 +1,115 @@
+package net.brightroom.endpointgate.core.condition;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+
+/**
+ * Immutable holder for request context variables available in condition expressions.
+ *
+ * <p>Instances are created via {@link ConditionVariablesBuilder}.
+ *
+ * <p>Available properties:
+ *
+ * <ul>
+ *   <li>{@code headers} — {@code Map<String, String>} of request headers (first value per name,
+ *       case-insensitive keys)
+ *   <li>{@code params} — {@code Map<String, String>} of query parameters (first value per name)
+ *   <li>{@code cookies} — {@code Map<String, String>} of cookie values keyed by cookie name
+ *   <li>{@code path} — {@code String} request path (e.g. {@code /api/resource})
+ *   <li>{@code method} — {@code String} HTTP method (e.g. {@code GET}, {@code POST})
+ *   <li>{@code remoteAddress} — {@code String} client IP address
+ * </ul>
+ */
+public final class ConditionVariables {
+
+  private final Map<String, String> headers;
+  private final Map<String, String> params;
+  private final Map<String, String> cookies;
+  private final String path;
+  private final String method;
+  private final String remoteAddress;
+
+  ConditionVariables(
+      Map<String, String> headers,
+      Map<String, String> params,
+      Map<String, String> cookies,
+      String path,
+      String method,
+      String remoteAddress) {
+    TreeMap<String, String> headersCopy = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    headersCopy.putAll(headers);
+    this.headers = Collections.unmodifiableMap(headersCopy);
+    this.params = Map.copyOf(params);
+    this.cookies = Map.copyOf(cookies);
+    this.path = path;
+    this.method = method;
+    this.remoteAddress = remoteAddress;
+  }
+
+  /** Returns the request headers as a case-insensitive map. */
+  public Map<String, String> headers() {
+    return headers;
+  }
+
+  /** Returns the query parameters. */
+  public Map<String, String> params() {
+    return params;
+  }
+
+  /** Returns the cookies. */
+  public Map<String, String> cookies() {
+    return cookies;
+  }
+
+  /** Returns the request path. */
+  public String path() {
+    return path;
+  }
+
+  /** Returns the HTTP method. */
+  public String method() {
+    return method;
+  }
+
+  /** Returns the client IP address. */
+  public String remoteAddress() {
+    return remoteAddress;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof ConditionVariables that)) return false;
+    return Objects.equals(headers, that.headers)
+        && Objects.equals(params, that.params)
+        && Objects.equals(cookies, that.cookies)
+        && Objects.equals(path, that.path)
+        && Objects.equals(method, that.method)
+        && Objects.equals(remoteAddress, that.remoteAddress);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(headers, params, cookies, path, method, remoteAddress);
+  }
+
+  @Override
+  public String toString() {
+    return "ConditionVariables["
+        + "headers="
+        + headers
+        + ", params="
+        + params
+        + ", cookies="
+        + cookies
+        + ", path="
+        + path
+        + ", method="
+        + method
+        + ", remoteAddress="
+        + remoteAddress
+        + ']';
+  }
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/condition/ConditionVariablesBuilder.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/condition/ConditionVariablesBuilder.java
@@ -1,0 +1,73 @@
+package net.brightroom.endpointgate.core.condition;
+
+import java.util.Map;
+
+/**
+ * Builder for constructing {@link ConditionVariables} passed to {@link
+ * EndpointGateConditionEvaluator}.
+ *
+ * <p>Centralizes the variable key names so that all modules ({@code webmvc}, {@code webflux}) use
+ * consistent keys. Each module extracts the request-specific data and delegates to this builder to
+ * construct the {@link ConditionVariables}.
+ *
+ * <p>Available variable keys:
+ *
+ * <ul>
+ *   <li>{@code headers} — {@code Map<String, String>} of request headers (first value per name)
+ *   <li>{@code params} — {@code Map<String, String>} of query parameters (first value per name)
+ *   <li>{@code cookies} — {@code Map<String, String>} of cookie values keyed by cookie name
+ *   <li>{@code path} — {@code String} request path (e.g. {@code /api/resource})
+ *   <li>{@code method} — {@code String} HTTP method (e.g. {@code GET}, {@code POST})
+ *   <li>{@code remoteAddress} — {@code String} client IP address
+ * </ul>
+ */
+public final class ConditionVariablesBuilder {
+
+  private Map<String, String> headers = Map.of();
+  private Map<String, String> params = Map.of();
+  private Map<String, String> cookies = Map.of();
+  private String path = "";
+  private String method = "";
+  private String remoteAddress = "";
+
+  /** Sets the {@code headers} variable. */
+  public ConditionVariablesBuilder headers(Map<String, String> headers) {
+    this.headers = headers;
+    return this;
+  }
+
+  /** Sets the {@code params} variable. */
+  public ConditionVariablesBuilder params(Map<String, String> params) {
+    this.params = params;
+    return this;
+  }
+
+  /** Sets the {@code cookies} variable. */
+  public ConditionVariablesBuilder cookies(Map<String, String> cookies) {
+    this.cookies = cookies;
+    return this;
+  }
+
+  /** Sets the {@code path} variable. */
+  public ConditionVariablesBuilder path(String path) {
+    this.path = path;
+    return this;
+  }
+
+  /** Sets the {@code method} variable. */
+  public ConditionVariablesBuilder method(String method) {
+    this.method = method;
+    return this;
+  }
+
+  /** Sets the {@code remoteAddress} variable. */
+  public ConditionVariablesBuilder remoteAddress(String remoteAddress) {
+    this.remoteAddress = remoteAddress;
+    return this;
+  }
+
+  /** Returns the built {@link ConditionVariables}. */
+  public ConditionVariables build() {
+    return new ConditionVariables(headers, params, cookies, path, method, remoteAddress);
+  }
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/condition/EndpointGateConditionEvaluator.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/condition/EndpointGateConditionEvaluator.java
@@ -1,0 +1,28 @@
+package net.brightroom.endpointgate.core.condition;
+
+/**
+ * SPI for evaluating condition expressions against request context variables.
+ *
+ * <p>Implementations evaluate an expression with the given variables and return whether the
+ * condition is satisfied.
+ *
+ * <p>Register a custom bean to replace the default implementation:
+ *
+ * <pre>{@code
+ * @Bean
+ * EndpointGateConditionEvaluator customEvaluator() {
+ *     return (expression, variables) -> ...;
+ * }
+ * }</pre>
+ */
+public interface EndpointGateConditionEvaluator {
+
+  /**
+   * Evaluates a condition expression against the given variables.
+   *
+   * @param expression the expression to evaluate
+   * @param variables the variables available in the expression context
+   * @return {@code true} if the condition is satisfied
+   */
+  boolean evaluate(String expression, ConditionVariables variables);
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/context/EndpointGateContext.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/context/EndpointGateContext.java
@@ -1,0 +1,28 @@
+package net.brightroom.endpointgate.core.context;
+
+import java.util.Objects;
+
+/**
+ * Holds the context for an endpoint gate rollout check.
+ *
+ * <p>The {@code userIdentifier} is used to deterministically bucket requests into rollout groups.
+ * For non-sticky (per-request random) rollout, implementations may pass a random UUID. For sticky
+ * rollout (same user always gets the same result), pass a stable identifier such as a user ID or
+ * session ID.
+ *
+ * @param userIdentifier a non-blank identifier used to bucket requests into rollout groups
+ */
+public record EndpointGateContext(String userIdentifier) {
+  /**
+   * Validates that {@code userIdentifier} is not null or blank.
+   *
+   * @throws NullPointerException if {@code userIdentifier} is null
+   * @throws IllegalArgumentException if {@code userIdentifier} is blank
+   */
+  public EndpointGateContext {
+    Objects.requireNonNull(userIdentifier, "userIdentifier must not be null");
+    if (userIdentifier.isBlank()) {
+      throw new IllegalArgumentException("userIdentifier must not be blank");
+    }
+  }
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/evaluation/AccessDecision.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/evaluation/AccessDecision.java
@@ -1,0 +1,47 @@
+package net.brightroom.endpointgate.core.evaluation;
+
+/**
+ * Represents the outcome of an endpoint gate evaluation pipeline.
+ *
+ * <p>Either {@link Allowed} (proceed) or {@link Denied} (block with a reason).
+ */
+public sealed interface AccessDecision {
+
+  /** Indicates that access is allowed. */
+  record Allowed() implements AccessDecision {}
+
+  /** Indicates that access is denied, with the gate identifier and reason. */
+  record Denied(String gateId, DeniedReason reason) implements AccessDecision {}
+
+  /** Reason for denying access in the evaluation pipeline. */
+  enum DeniedReason {
+    /** The gate is disabled. */
+    DISABLED,
+    /** The gate has a schedule that is not currently active. */
+    SCHEDULE_INACTIVE,
+    /** The condition evaluated to false. */
+    CONDITION_NOT_MET,
+    /** The request is outside the rollout bucket. */
+    ROLLOUT_EXCLUDED
+  }
+
+  /**
+   * Returns an {@link Allowed} decision.
+   *
+   * @return a new {@code Allowed} instance
+   */
+  static AccessDecision allowed() {
+    return new Allowed();
+  }
+
+  /**
+   * Returns a {@link Denied} decision.
+   *
+   * @param gateId the gate identifier that was denied
+   * @param reason the reason for denial
+   * @return a new {@code Denied} instance
+   */
+  static AccessDecision denied(String gateId, DeniedReason reason) {
+    return new Denied(gateId, reason);
+  }
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/evaluation/ConditionEvaluationStep.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/evaluation/ConditionEvaluationStep.java
@@ -1,0 +1,31 @@
+package net.brightroom.endpointgate.core.evaluation;
+
+import java.util.Optional;
+import net.brightroom.endpointgate.core.condition.EndpointGateConditionEvaluator;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision.DeniedReason;
+
+/** Evaluation step that checks the condition expression. */
+public class ConditionEvaluationStep implements EvaluationStep {
+
+  private final EndpointGateConditionEvaluator conditionEvaluator;
+
+  /**
+   * Creates a new {@code ConditionEvaluationStep}.
+   *
+   * @param conditionEvaluator the evaluator used to evaluate condition expressions
+   */
+  public ConditionEvaluationStep(EndpointGateConditionEvaluator conditionEvaluator) {
+    this.conditionEvaluator = conditionEvaluator;
+  }
+
+  @Override
+  public Optional<AccessDecision> evaluate(EvaluationContext context) {
+    if (context.condition().isEmpty()) {
+      return Optional.empty();
+    }
+    if (!conditionEvaluator.evaluate(context.condition(), context.variables())) {
+      return Optional.of(AccessDecision.denied(context.gateId(), DeniedReason.CONDITION_NOT_MET));
+    }
+    return Optional.empty();
+  }
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/evaluation/EnabledEvaluationStep.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/evaluation/EnabledEvaluationStep.java
@@ -1,0 +1,28 @@
+package net.brightroom.endpointgate.core.evaluation;
+
+import java.util.Optional;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision.DeniedReason;
+import net.brightroom.endpointgate.core.provider.EndpointGateProvider;
+
+/** Evaluation step that checks whether the gate is enabled. */
+public class EnabledEvaluationStep implements EvaluationStep {
+
+  private final EndpointGateProvider provider;
+
+  /**
+   * Creates a new {@code EnabledEvaluationStep}.
+   *
+   * @param provider the provider used to check whether a gate is enabled
+   */
+  public EnabledEvaluationStep(EndpointGateProvider provider) {
+    this.provider = provider;
+  }
+
+  @Override
+  public Optional<AccessDecision> evaluate(EvaluationContext context) {
+    if (!provider.isGateEnabled(context.gateId())) {
+      return Optional.of(AccessDecision.denied(context.gateId(), DeniedReason.DISABLED));
+    }
+    return Optional.empty();
+  }
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/evaluation/EndpointGateEvaluationPipeline.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/evaluation/EndpointGateEvaluationPipeline.java
@@ -1,0 +1,57 @@
+package net.brightroom.endpointgate.core.evaluation;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Synchronous endpoint gate evaluation pipeline.
+ *
+ * <p>Executes the four built-in {@link EvaluationStep}s in a fixed order:
+ *
+ * <ol>
+ *   <li>{@link EnabledEvaluationStep} — checks whether the gate is enabled
+ *   <li>{@link ScheduleEvaluationStep} — checks whether the schedule is active
+ *   <li>{@link ConditionEvaluationStep} — evaluates the condition expression
+ *   <li>{@link RolloutEvaluationStep} — checks rollout bucket membership
+ * </ol>
+ *
+ * <p>Returns the first {@link AccessDecision.Denied} encountered, or {@link AccessDecision.Allowed}
+ * if all steps pass.
+ */
+public class EndpointGateEvaluationPipeline {
+
+  private final List<EvaluationStep> steps;
+
+  /**
+   * Creates a new {@code EndpointGateEvaluationPipeline} with the fixed evaluation order.
+   *
+   * @param enabledStep the step that checks whether the gate is enabled
+   * @param scheduleStep the step that checks the schedule
+   * @param conditionStep the step that evaluates the condition expression
+   * @param rolloutStep the step that checks rollout bucket membership
+   */
+  public EndpointGateEvaluationPipeline(
+      EnabledEvaluationStep enabledStep,
+      ScheduleEvaluationStep scheduleStep,
+      ConditionEvaluationStep conditionStep,
+      RolloutEvaluationStep rolloutStep) {
+    this.steps = List.of(enabledStep, scheduleStep, conditionStep, rolloutStep);
+  }
+
+  /**
+   * Evaluates all steps in order and returns the first denied decision or {@link
+   * AccessDecision#allowed()} if all steps pass.
+   *
+   * @param context the evaluation context
+   * @return the access decision
+   */
+  public AccessDecision evaluate(EvaluationContext context) {
+    for (EvaluationStep step : steps) {
+      Optional<AccessDecision> result = step.evaluate(context);
+      if (result.isPresent()) {
+        return result.get();
+      }
+    }
+    return AccessDecision.allowed();
+  }
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/evaluation/EvaluationContext.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/evaluation/EvaluationContext.java
@@ -1,0 +1,37 @@
+package net.brightroom.endpointgate.core.evaluation;
+
+import java.util.function.Supplier;
+import net.brightroom.endpointgate.core.condition.ConditionVariables;
+import net.brightroom.endpointgate.core.context.EndpointGateContext;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Immutable context object passed through the {@link EndpointGateEvaluationPipeline}.
+ *
+ * <p>Contains all inputs required by the default evaluation steps. Callers are responsible for
+ * resolving the rollout percentage (merging provider value and annotation fallback) before building
+ * this context.
+ *
+ * @param gateId the identifier of the gate being evaluated
+ * @param condition the condition expression; empty string means no condition check. {@code null} is
+ *     normalized to empty string.
+ * @param rolloutPercentage the resolved rollout percentage (0–100)
+ * @param variables the request context variables used for condition evaluation
+ * @param gateContextSupplier lazy supplier for the context used for rollout bucketing; the supplier
+ *     may return {@code null} which means fail-open (skip rollout check)
+ */
+public record EvaluationContext(
+    @NonNull String gateId,
+    @NonNull String condition,
+    int rolloutPercentage,
+    ConditionVariables variables,
+    Supplier<@Nullable EndpointGateContext> gateContextSupplier) {
+
+  /** Compact constructor that normalizes {@code null} condition to empty string. */
+  public EvaluationContext {
+    if (condition == null) {
+      condition = "";
+    }
+  }
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/evaluation/EvaluationStep.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/evaluation/EvaluationStep.java
@@ -1,0 +1,20 @@
+package net.brightroom.endpointgate.core.evaluation;
+
+import java.util.Optional;
+
+/**
+ * SPI for a single step in the synchronous endpoint gate evaluation pipeline.
+ *
+ * <p>Implement this interface to add a custom evaluation step.
+ */
+public interface EvaluationStep {
+
+  /**
+   * Evaluates one step of the gate decision pipeline.
+   *
+   * @param context the evaluation context containing all inputs for this step
+   * @return {@link Optional#empty()} if this step passes (proceed to the next step), or an {@link
+   *     Optional} containing an {@link AccessDecision.Denied} if this step rejects the request
+   */
+  Optional<AccessDecision> evaluate(EvaluationContext context);
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/evaluation/RolloutEvaluationStep.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/evaluation/RolloutEvaluationStep.java
@@ -1,0 +1,36 @@
+package net.brightroom.endpointgate.core.evaluation;
+
+import java.util.Optional;
+import net.brightroom.endpointgate.core.context.EndpointGateContext;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision.DeniedReason;
+import net.brightroom.endpointgate.core.rollout.RolloutStrategy;
+
+/** Evaluation step that checks whether the request is within the rollout bucket. */
+public class RolloutEvaluationStep implements EvaluationStep {
+
+  private final RolloutStrategy rolloutStrategy;
+
+  /**
+   * Creates a new {@code RolloutEvaluationStep}.
+   *
+   * @param rolloutStrategy the strategy used to determine rollout bucket membership
+   */
+  public RolloutEvaluationStep(RolloutStrategy rolloutStrategy) {
+    this.rolloutStrategy = rolloutStrategy;
+  }
+
+  @Override
+  public Optional<AccessDecision> evaluate(EvaluationContext context) {
+    if (context.rolloutPercentage() >= 100) {
+      return Optional.empty();
+    }
+    EndpointGateContext gateContext = context.gateContextSupplier().get();
+    if (gateContext == null) {
+      return Optional.empty(); // fail-open: no context available
+    }
+    if (!rolloutStrategy.isInRollout(context.gateId(), gateContext, context.rolloutPercentage())) {
+      return Optional.of(AccessDecision.denied(context.gateId(), DeniedReason.ROLLOUT_EXCLUDED));
+    }
+    return Optional.empty();
+  }
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/evaluation/ScheduleEvaluationStep.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/evaluation/ScheduleEvaluationStep.java
@@ -1,0 +1,32 @@
+package net.brightroom.endpointgate.core.evaluation;
+
+import java.time.Clock;
+import java.util.Optional;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision.DeniedReason;
+import net.brightroom.endpointgate.core.provider.ScheduleProvider;
+
+/** Evaluation step that checks whether the gate schedule is currently active. */
+public class ScheduleEvaluationStep implements EvaluationStep {
+
+  private final ScheduleProvider scheduleProvider;
+  private final Clock clock;
+
+  /**
+   * Creates a new {@code ScheduleEvaluationStep}.
+   *
+   * @param scheduleProvider the provider used to look up the schedule per gate
+   * @param clock the clock used to obtain the current time for schedule evaluation
+   */
+  public ScheduleEvaluationStep(ScheduleProvider scheduleProvider, Clock clock) {
+    this.scheduleProvider = scheduleProvider;
+    this.clock = clock;
+  }
+
+  @Override
+  public Optional<AccessDecision> evaluate(EvaluationContext context) {
+    return scheduleProvider
+        .getSchedule(context.gateId())
+        .filter(schedule -> !schedule.isActive(clock.instant()))
+        .map(schedule -> AccessDecision.denied(context.gateId(), DeniedReason.SCHEDULE_INACTIVE));
+  }
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/exception/EndpointGateAccessDeniedException.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/exception/EndpointGateAccessDeniedException.java
@@ -1,0 +1,34 @@
+package net.brightroom.endpointgate.core.exception;
+
+/**
+ * Thrown when access to a gate-protected endpoint is denied.
+ *
+ * <p>This exception can be caught by a {@code @ControllerAdvice} to customize the response. If not
+ * handled, the library's default response behavior applies.
+ */
+public class EndpointGateAccessDeniedException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  /** The identifier of the gate that is not available. */
+  private final String gateId;
+
+  /**
+   * Constructor.
+   *
+   * @param gateId the identifier of the gate that is not available
+   */
+  public EndpointGateAccessDeniedException(String gateId) {
+    super(String.format("Gate '%s' is not available", gateId));
+    this.gateId = gateId;
+  }
+
+  /**
+   * Returns the identifier of the gate that is not available.
+   *
+   * @return the identifier of the gate
+   */
+  public String gateId() {
+    return gateId;
+  }
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/properties/ConditionProperties.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/properties/ConditionProperties.java
@@ -1,0 +1,37 @@
+package net.brightroom.endpointgate.core.properties;
+
+/**
+ * Properties for endpoint gate condition evaluation behavior.
+ *
+ * <p>Configuration example in {@code application.yml}:
+ *
+ * <pre>{@code
+ * endpoint-gate:
+ *   condition:
+ *     fail-on-error: true
+ * }</pre>
+ *
+ * <p>When {@code fail-on-error} is {@code true} (default), condition evaluation errors cause the
+ * gate to be denied (fail-closed). When {@code false}, errors cause the condition check to be
+ * skipped (fail-open).
+ */
+public class ConditionProperties {
+
+  private boolean failOnError = true;
+
+  /**
+   * Returns whether condition evaluation errors should cause access denial.
+   *
+   * @return {@code true} for fail-closed (default), {@code false} for fail-open
+   */
+  public boolean failOnError() {
+    return failOnError;
+  }
+
+  // for property binding
+  void setFailOnError(boolean failOnError) {
+    this.failOnError = failOnError;
+  }
+
+  ConditionProperties() {}
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/properties/GateProperties.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/properties/GateProperties.java
@@ -1,0 +1,99 @@
+package net.brightroom.endpointgate.core.properties;
+
+/**
+ * Configuration for a single endpoint gate, including its enabled status, rollout percentage,
+ * optional condition expression, and optional schedule.
+ *
+ * <p>Used as the value type for {@code endpoint-gate.gates} in configuration.
+ *
+ * <p>Configuration example in {@code application.yml}:
+ *
+ * <pre>{@code
+ * endpoint-gate:
+ *   gates:
+ *     new-feature:
+ *       enabled: true
+ *       rollout: 50
+ *       condition: "headers['X-Beta'] != null"
+ *     christmas-sale:
+ *       enabled: true
+ *       schedule:
+ *         start: "2026-12-25T00:00:00"
+ *         end: "2027-01-05T23:59:59"
+ *         timezone: "Asia/Tokyo"
+ *     simple-feature:
+ *       enabled: true
+ * }</pre>
+ */
+public class GateProperties {
+
+  private boolean enabled = true;
+  private int rollout = 100;
+  private String condition = "";
+  private ScheduleProperties schedule;
+
+  /**
+   * Returns whether this gate is enabled.
+   *
+   * @return {@code true} if the gate is enabled, {@code false} otherwise
+   */
+  public boolean enabled() {
+    return enabled;
+  }
+
+  /**
+   * Returns the rollout percentage for this gate (0–100).
+   *
+   * <p>100 means fully enabled (all requests). 0 means effectively disabled (no requests even if
+   * the gate is enabled).
+   *
+   * @return the rollout percentage
+   */
+  public int rollout() {
+    return rollout;
+  }
+
+  /**
+   * Returns the condition expression for this gate, or an empty string if no condition is
+   * configured.
+   *
+   * @return the condition expression, or empty string
+   */
+  public String condition() {
+    return condition;
+  }
+
+  /**
+   * Returns the schedule configuration for this gate, or {@code null} if no schedule is configured.
+   *
+   * @return the schedule configuration, or {@code null}
+   */
+  public ScheduleProperties schedule() {
+    return schedule;
+  }
+
+  // for property binding
+  void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  // for property binding
+  void setRollout(int rollout) {
+    if (rollout < 0 || rollout > 100) {
+      throw new IllegalArgumentException("rollout must be between 0 and 100, but was: " + rollout);
+    }
+    this.rollout = rollout;
+  }
+
+  // for property binding
+  void setCondition(String condition) {
+    this.condition = condition != null ? condition : "";
+  }
+
+  // for property binding
+  void setSchedule(ScheduleProperties schedule) {
+    this.schedule = schedule;
+  }
+
+  GateProperties() {}
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/properties/ResponseProperties.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/properties/ResponseProperties.java
@@ -1,0 +1,28 @@
+package net.brightroom.endpointgate.core.properties;
+
+/**
+ * Properties related to the response configuration.
+ *
+ * <p>This class encapsulates configuration properties for the response format and type, allowing
+ * customization of how responses are generated and returned by the system.
+ */
+public class ResponseProperties {
+
+  ResponseType type = ResponseType.JSON;
+
+  /**
+   * The type of response to return.
+   *
+   * @return the type of response
+   */
+  public ResponseType type() {
+    return type;
+  }
+
+  // for property binding
+  void setType(ResponseType type) {
+    this.type = type;
+  }
+
+  ResponseProperties() {}
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/properties/ResponseType.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/properties/ResponseType.java
@@ -1,0 +1,21 @@
+package net.brightroom.endpointgate.core.properties;
+
+/**
+ * Represents the type of response to be returned by the system.
+ *
+ * <ul>
+ *   <li>PLAIN_TEXT: Denotes a plain text response.
+ *   <li>JSON: Denotes a JSON-formatted response.
+ *   <li>HTML: Denotes a simple fixed HTML response.
+ * </ul>
+ */
+public enum ResponseType {
+  /** Plain text response. */
+  PLAIN_TEXT,
+
+  /** JSON response. */
+  JSON,
+
+  /** HTML response. */
+  HTML
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/properties/ScheduleProperties.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/properties/ScheduleProperties.java
@@ -1,0 +1,105 @@
+package net.brightroom.endpointgate.core.properties;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import net.brightroom.endpointgate.core.provider.Schedule;
+
+/**
+ * Configuration for the schedule window of a single endpoint gate.
+ *
+ * <p>Defines an optional {@code start} and {@code end} time (as {@link LocalDateTime}) and an
+ * optional {@code timezone}. Use {@link #toSchedule()} to obtain the {@link Schedule} SPI value
+ * object which provides the {@code isActive(Instant)} evaluation logic.
+ *
+ * <p>Configuration example in {@code application.yml}:
+ *
+ * <pre>{@code
+ * endpoint-gate:
+ *   gates:
+ *     christmas-sale:
+ *       enabled: true
+ *       schedule:
+ *         start: "2026-12-25T00:00:00"
+ *         end: "2027-01-05T23:59:59"
+ *         timezone: "Asia/Tokyo"
+ * }</pre>
+ *
+ * <ul>
+ *   <li>{@code start} only — the gate is active from {@code start} onward
+ *   <li>{@code end} only — the gate is active until {@code end}
+ *   <li>both — the gate is active between {@code start} and {@code end} (inclusive)
+ *   <li>neither — the gate is always active (equivalent to no schedule)
+ *   <li>{@code timezone} omitted — system default timezone is used
+ * </ul>
+ */
+public class ScheduleProperties {
+
+  private LocalDateTime start;
+  private LocalDateTime end;
+  private ZoneId timezone;
+
+  /**
+   * Converts this property binding object to the SPI value type.
+   *
+   * @return a new {@link Schedule} with the same start, end, and timezone values
+   */
+  Schedule toSchedule() {
+    return new Schedule(start, end, timezone);
+  }
+
+  /**
+   * Returns the schedule start time, or {@code null} if no start restriction is configured.
+   *
+   * @return the start time, or {@code null}
+   */
+  public LocalDateTime start() {
+    return start;
+  }
+
+  /**
+   * Returns the schedule end time, or {@code null} if no end restriction is configured.
+   *
+   * @return the end time, or {@code null}
+   */
+  public LocalDateTime end() {
+    return end;
+  }
+
+  /**
+   * Returns the timezone used to evaluate start/end times, or {@code null} if the system default
+   * timezone should be used.
+   *
+   * @return the timezone, or {@code null}
+   */
+  public ZoneId timezone() {
+    return timezone;
+  }
+
+  // for property binding
+  void setStart(LocalDateTime start) {
+    if (start != null && this.end != null && start.isAfter(this.end)) {
+      throw new IllegalArgumentException(
+          "schedule.start must not be after schedule.end, but start=" + start + " end=" + this.end);
+    }
+    this.start = start;
+  }
+
+  // for property binding
+  void setEnd(LocalDateTime end) {
+    if (end != null && this.start != null && end.isBefore(this.start)) {
+      throw new IllegalArgumentException(
+          "schedule.end must not be before schedule.start, but end="
+              + end
+              + " start="
+              + this.start);
+    }
+    this.end = end;
+  }
+
+  // for property binding
+  void setTimezone(ZoneId timezone) {
+    this.timezone = timezone;
+  }
+
+  ScheduleProperties() {}
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/provider/ConditionProvider.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/provider/ConditionProvider.java
@@ -1,0 +1,22 @@
+package net.brightroom.endpointgate.core.provider;
+
+import java.util.Optional;
+
+/**
+ * SPI for resolving the condition expression for a given endpoint gate.
+ *
+ * <p>Implementations provide the configured condition expression for each gate. When a gate has no
+ * configured condition, {@link Optional#empty()} is returned and the gate is treated as having no
+ * condition restriction.
+ */
+public interface ConditionProvider {
+
+  /**
+   * Returns the configured condition expression for the specified gate.
+   *
+   * @param gateId the identifier of the gate
+   * @return an {@link Optional} containing the condition expression, or {@link Optional#empty()} if
+   *     no condition is configured for this gate
+   */
+  Optional<String> getCondition(String gateId);
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/provider/EndpointGateProvider.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/provider/EndpointGateProvider.java
@@ -1,0 +1,28 @@
+package net.brightroom.endpointgate.core.provider;
+
+/**
+ * Provides a mechanism to check the status of endpoint gates within an application.
+ *
+ * <p>The {@code EndpointGateProvider} interface allows implementations to define how gates are
+ * stored and accessed, enabling a consistent method for determining whether a specific gate is
+ * enabled or disabled at runtime.
+ *
+ * <p><b>Undefined gate policy:</b> Implementations must decide what to return when {@code gateId}
+ * is not known to the provider. The built-in {@link InMemoryEndpointGateProvider} uses a
+ * <em>fail-closed</em> policy by default (returns {@code false} for unknown gates), which can be
+ * changed to fail-open via {@code endpoint-gate.default-enabled: true}. Custom implementations
+ * should document their own policy clearly.
+ */
+public interface EndpointGateProvider {
+
+  /**
+   * Determines whether a specific gate is enabled.
+   *
+   * <p>The return value for a gate identifier that is not managed by this provider is
+   * implementation-defined. See the implementing class for its undefined-gate policy.
+   *
+   * @param gateId the identifier of the gate whose status is to be verified
+   * @return {@code true} if the gate is enabled, {@code false} otherwise
+   */
+  boolean isGateEnabled(String gateId);
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/provider/InMemoryConditionProvider.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/provider/InMemoryConditionProvider.java
@@ -1,0 +1,29 @@
+package net.brightroom.endpointgate.core.provider;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * An implementation of {@link ConditionProvider} that stores condition expressions in memory using
+ * a {@link Map}.
+ */
+public class InMemoryConditionProvider implements ConditionProvider {
+
+  private final Map<String, String> conditions;
+
+  /** {@inheritDoc} */
+  @Override
+  public Optional<String> getCondition(String gateId) {
+    return Optional.ofNullable(conditions.get(gateId));
+  }
+
+  /**
+   * Constructs an instance with the provided condition expressions.
+   *
+   * @param conditions a map containing gate identifiers as keys and their condition expressions as
+   *     values; copied defensively on construction
+   */
+  public InMemoryConditionProvider(Map<String, String> conditions) {
+    this.conditions = Map.copyOf(conditions);
+  }
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/provider/InMemoryEndpointGateProvider.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/provider/InMemoryEndpointGateProvider.java
@@ -1,0 +1,43 @@
+package net.brightroom.endpointgate.core.provider;
+
+import java.util.Map;
+
+/**
+ * An implementation of {@link EndpointGateProvider} that stores gate configurations in memory using
+ * a {@link Map}.
+ *
+ * <p>This class provides a simple mechanism to check whether specific gates are enabled or disabled
+ * based on an in-memory map.
+ */
+public class InMemoryEndpointGateProvider implements EndpointGateProvider {
+
+  private final Map<String, Boolean> gates;
+  private final boolean defaultEnabled;
+
+  /**
+   * Returns whether the specified gate is enabled.
+   *
+   * <p><b>Fail-closed behavior (default):</b> If {@code gateId} is not present in the gate map,
+   * this method returns the value of {@code defaultEnabled} (defaults to {@code false}).
+   *
+   * @param gateId the identifier of the gate to check
+   * @return {@code true} if the gate is explicitly enabled, {@code false} if explicitly disabled or
+   *     not configured (with default fail-closed behavior)
+   */
+  @Override
+  public boolean isGateEnabled(String gateId) {
+    return gates.getOrDefault(gateId, defaultEnabled);
+  }
+
+  /**
+   * Constructs an instance with the provided gates and default enabled status.
+   *
+   * @param gates a map containing gate identifiers as keys and their activation status as values;
+   *     copied defensively on construction
+   * @param defaultEnabled the default enabled status for gates not present in the map
+   */
+  public InMemoryEndpointGateProvider(Map<String, Boolean> gates, boolean defaultEnabled) {
+    this.gates = Map.copyOf(gates);
+    this.defaultEnabled = defaultEnabled;
+  }
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/provider/InMemoryRolloutPercentageProvider.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/provider/InMemoryRolloutPercentageProvider.java
@@ -1,0 +1,30 @@
+package net.brightroom.endpointgate.core.provider;
+
+import java.util.Map;
+import java.util.OptionalInt;
+
+/**
+ * An implementation of {@link RolloutPercentageProvider} that stores rollout percentages in memory
+ * using a {@link Map}.
+ */
+public class InMemoryRolloutPercentageProvider implements RolloutPercentageProvider {
+
+  private final Map<String, Integer> rolloutPercentages;
+
+  /** {@inheritDoc} */
+  @Override
+  public OptionalInt getRolloutPercentage(String gateId) {
+    Integer percentage = rolloutPercentages.get(gateId);
+    return percentage != null ? OptionalInt.of(percentage) : OptionalInt.empty();
+  }
+
+  /**
+   * Constructs an instance with the provided rollout percentages.
+   *
+   * @param rolloutPercentages a map containing gate identifiers as keys and their rollout
+   *     percentages as values; copied defensively on construction
+   */
+  public InMemoryRolloutPercentageProvider(Map<String, Integer> rolloutPercentages) {
+    this.rolloutPercentages = Map.copyOf(rolloutPercentages);
+  }
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/provider/InMemoryScheduleProvider.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/provider/InMemoryScheduleProvider.java
@@ -1,0 +1,29 @@
+package net.brightroom.endpointgate.core.provider;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * An implementation of {@link ScheduleProvider} that stores schedule configurations in memory using
+ * a {@link Map}.
+ */
+public class InMemoryScheduleProvider implements ScheduleProvider {
+
+  private final Map<String, Schedule> schedules;
+
+  /** {@inheritDoc} */
+  @Override
+  public Optional<Schedule> getSchedule(String gateId) {
+    return Optional.ofNullable(schedules.get(gateId));
+  }
+
+  /**
+   * Constructs an instance with the provided schedule configurations.
+   *
+   * @param schedules a map containing gate identifiers as keys and their schedule configurations as
+   *     values; copied defensively on construction
+   */
+  public InMemoryScheduleProvider(Map<String, Schedule> schedules) {
+    this.schedules = Map.copyOf(schedules);
+  }
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/provider/MutableConditionProvider.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/provider/MutableConditionProvider.java
@@ -1,0 +1,41 @@
+package net.brightroom.endpointgate.core.provider;
+
+import java.util.Map;
+
+/**
+ * An extension of {@link ConditionProvider} that supports dynamic mutation of condition expressions
+ * at runtime.
+ *
+ * <p>Implementations must be thread-safe, as conditions may be read and updated concurrently.
+ */
+public interface MutableConditionProvider extends ConditionProvider {
+
+  /**
+   * Returns a snapshot of all currently configured condition expressions.
+   *
+   * <p>The returned map must be an immutable copy; mutations to the returned map must not affect
+   * the provider's internal state.
+   *
+   * @return an immutable map of gate identifiers to their condition expressions
+   */
+  Map<String, String> getConditions();
+
+  /**
+   * Updates the condition expression for the specified gate.
+   *
+   * <p>If the gate does not have a configured condition, it is created.
+   *
+   * @param gateId the identifier of the gate to update
+   * @param condition the new condition expression; must not be null
+   */
+  void setCondition(String gateId, String condition);
+
+  /**
+   * Removes the condition expression for the specified gate.
+   *
+   * <p>If the gate does not have a configured condition, this method is a no-op.
+   *
+   * @param gateId the identifier of the gate whose condition to remove
+   */
+  void removeCondition(String gateId);
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/provider/MutableEndpointGateProvider.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/provider/MutableEndpointGateProvider.java
@@ -1,0 +1,45 @@
+package net.brightroom.endpointgate.core.provider;
+
+import java.util.Map;
+
+/**
+ * An extension of {@link EndpointGateProvider} that supports dynamic mutation of gates at runtime.
+ *
+ * <p>Implementations must be thread-safe, as gates may be read and updated concurrently.
+ *
+ * <p>This interface serves as an SPI for external storage backends (e.g., Redis, databases) that
+ * need to expose mutable gate state without depending on the {@code actuator} module.
+ */
+public interface MutableEndpointGateProvider extends EndpointGateProvider {
+
+  /**
+   * Returns a snapshot of all currently configured gates and their enabled states.
+   *
+   * <p>The returned map must be an immutable copy; mutations to the returned map must not affect
+   * the provider's internal state.
+   *
+   * @return an immutable map of gate identifiers to their enabled states
+   */
+  Map<String, Boolean> getGates();
+
+  /**
+   * Updates the enabled state of the specified gate.
+   *
+   * <p>If the gate does not exist, it must be created with the given state.
+   *
+   * @param gateId the identifier of the gate to update
+   * @param enabled {@code true} to enable the gate, {@code false} to disable it
+   */
+  void setGateEnabled(String gateId, boolean enabled);
+
+  /**
+   * Removes the specified gate from this provider.
+   *
+   * <p>After removal, {@link #isGateEnabled(String)} for this gate will return the default enabled
+   * value. If the gate does not exist, this method is a no-op and returns {@code false}.
+   *
+   * @param gateId the identifier of the gate to remove
+   * @return {@code true} if the gate existed and was removed, {@code false} if it did not exist
+   */
+  boolean removeGate(String gateId);
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/provider/MutableInMemoryConditionProvider.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/provider/MutableInMemoryConditionProvider.java
@@ -1,0 +1,50 @@
+package net.brightroom.endpointgate.core.provider;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A thread-safe, in-memory implementation of {@link MutableConditionProvider}.
+ *
+ * <p>Condition expressions are stored in a {@link ConcurrentHashMap}, allowing concurrent reads and
+ * writes without external synchronization.
+ */
+public class MutableInMemoryConditionProvider implements MutableConditionProvider {
+
+  private final ConcurrentHashMap<String, String> conditions;
+
+  /** {@inheritDoc} */
+  @Override
+  public Optional<String> getCondition(String gateId) {
+    return Optional.ofNullable(conditions.get(gateId));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Map<String, String> getConditions() {
+    return Map.copyOf(conditions);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setCondition(String gateId, String condition) {
+    conditions.put(gateId, condition);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void removeCondition(String gateId) {
+    conditions.remove(gateId);
+  }
+
+  /**
+   * Constructs a {@code MutableInMemoryConditionProvider} with the given initial condition
+   * expressions.
+   *
+   * @param conditions the initial condition expressions map; copied defensively on construction
+   */
+  public MutableInMemoryConditionProvider(Map<String, String> conditions) {
+    this.conditions = new ConcurrentHashMap<>(conditions);
+  }
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/provider/MutableInMemoryEndpointGateProvider.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/provider/MutableInMemoryEndpointGateProvider.java
@@ -1,0 +1,52 @@
+package net.brightroom.endpointgate.core.provider;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A thread-safe, in-memory implementation of {@link MutableEndpointGateProvider}.
+ *
+ * <p>Gates are stored in a {@link ConcurrentHashMap}, allowing concurrent reads and writes without
+ * external synchronization.
+ */
+public class MutableInMemoryEndpointGateProvider implements MutableEndpointGateProvider {
+
+  private final ConcurrentHashMap<String, Boolean> gates;
+  private final boolean defaultEnabled;
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean isGateEnabled(String gateId) {
+    return gates.getOrDefault(gateId, defaultEnabled);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Map<String, Boolean> getGates() {
+    return Map.copyOf(gates);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setGateEnabled(String gateId, boolean enabled) {
+    gates.put(gateId, enabled);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean removeGate(String gateId) {
+    return gates.remove(gateId) != null;
+  }
+
+  /**
+   * Constructs a {@code MutableInMemoryEndpointGateProvider} with the given initial gates and
+   * default enabled state.
+   *
+   * @param gates the initial gate map; copied defensively on construction
+   * @param defaultEnabled the fallback value for gates not present in the map
+   */
+  public MutableInMemoryEndpointGateProvider(Map<String, Boolean> gates, boolean defaultEnabled) {
+    this.gates = new ConcurrentHashMap<>(gates);
+    this.defaultEnabled = defaultEnabled;
+  }
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/provider/MutableInMemoryRolloutPercentageProvider.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/provider/MutableInMemoryRolloutPercentageProvider.java
@@ -1,0 +1,56 @@
+package net.brightroom.endpointgate.core.provider;
+
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A thread-safe, in-memory implementation of {@link MutableRolloutPercentageProvider}.
+ *
+ * <p>Rollout percentages are stored in a {@link ConcurrentHashMap}, allowing concurrent reads and
+ * writes without external synchronization.
+ */
+public class MutableInMemoryRolloutPercentageProvider implements MutableRolloutPercentageProvider {
+
+  private final ConcurrentHashMap<String, Integer> rolloutPercentages;
+
+  /** {@inheritDoc} */
+  @Override
+  public OptionalInt getRolloutPercentage(String gateId) {
+    Integer percentage = rolloutPercentages.get(gateId);
+    return percentage != null ? OptionalInt.of(percentage) : OptionalInt.empty();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Map<String, Integer> getRolloutPercentages() {
+    return Map.copyOf(rolloutPercentages);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setRolloutPercentage(String gateId, int percentage) {
+    if (percentage < 0 || percentage > 100) {
+      throw new IllegalArgumentException(
+          "percentage must be between 0 and 100, but was: " + percentage);
+    }
+    rolloutPercentages.put(gateId, percentage);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void removeRolloutPercentage(String gateId) {
+    rolloutPercentages.remove(gateId);
+  }
+
+  /**
+   * Constructs a {@code MutableInMemoryRolloutPercentageProvider} with the given initial rollout
+   * percentages.
+   *
+   * @param rolloutPercentages the initial rollout percentage map; copied defensively on
+   *     construction
+   */
+  public MutableInMemoryRolloutPercentageProvider(Map<String, Integer> rolloutPercentages) {
+    this.rolloutPercentages = new ConcurrentHashMap<>(rolloutPercentages);
+  }
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/provider/MutableRolloutPercentageProvider.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/provider/MutableRolloutPercentageProvider.java
@@ -1,0 +1,42 @@
+package net.brightroom.endpointgate.core.provider;
+
+import java.util.Map;
+
+/**
+ * An extension of {@link RolloutPercentageProvider} that supports dynamic mutation of rollout
+ * percentages at runtime.
+ *
+ * <p>Implementations must be thread-safe, as rollout percentages may be read and updated
+ * concurrently.
+ */
+public interface MutableRolloutPercentageProvider extends RolloutPercentageProvider {
+
+  /**
+   * Returns a snapshot of all currently configured rollout percentages.
+   *
+   * <p>The returned map must be an immutable copy; mutations to the returned map must not affect
+   * the provider's internal state.
+   *
+   * @return an immutable map of gate identifiers to their rollout percentages
+   */
+  Map<String, Integer> getRolloutPercentages();
+
+  /**
+   * Updates the rollout percentage for the specified gate.
+   *
+   * <p>If the gate does not have a configured rollout percentage, it is created.
+   *
+   * @param gateId the identifier of the gate to update
+   * @param percentage the new rollout percentage (0–100)
+   */
+  void setRolloutPercentage(String gateId, int percentage);
+
+  /**
+   * Removes the rollout percentage for the specified gate.
+   *
+   * <p>If the gate does not have a configured rollout percentage, this method is a no-op.
+   *
+   * @param gateId the identifier of the gate whose rollout percentage to remove
+   */
+  void removeRolloutPercentage(String gateId);
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/provider/RolloutPercentageProvider.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/provider/RolloutPercentageProvider.java
@@ -1,0 +1,21 @@
+package net.brightroom.endpointgate.core.provider;
+
+import java.util.OptionalInt;
+
+/**
+ * SPI for resolving the rollout percentage for a given endpoint gate.
+ *
+ * <p>Implementations provide the configured rollout percentage for each gate. When a gate has no
+ * configured rollout percentage, {@link OptionalInt#empty()} is returned.
+ */
+public interface RolloutPercentageProvider {
+
+  /**
+   * Returns the configured rollout percentage for the specified gate.
+   *
+   * @param gateId the identifier of the gate
+   * @return an {@link OptionalInt} containing the rollout percentage (0–100), or {@link
+   *     OptionalInt#empty()} if no rollout percentage is configured for this gate
+   */
+  OptionalInt getRolloutPercentage(String gateId);
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/provider/Schedule.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/provider/Schedule.java
@@ -1,0 +1,58 @@
+package net.brightroom.endpointgate.core.provider;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * An immutable value object representing the schedule window of an endpoint gate.
+ *
+ * <p>Defines an optional {@code start} and {@code end} time (as {@link LocalDateTime}) and an
+ * optional {@code timezone}. When {@link #isActive(Instant)} is called, the instant is converted to
+ * the configured timezone (or system default if absent) and compared against the window.
+ *
+ * <p>This is the SPI return type for {@link ScheduleProvider}. Custom provider implementations
+ * should create instances directly:
+ *
+ * <pre>{@code
+ * return Optional.of(new Schedule(startTime, endTime, ZoneId.of("Asia/Tokyo")));
+ * }</pre>
+ *
+ * <ul>
+ *   <li>{@code start} only — the gate is active from {@code start} onward
+ *   <li>{@code end} only — the gate is active until {@code end}
+ *   <li>both — the gate is active between {@code start} and {@code end} (inclusive)
+ *   <li>neither — the gate is always active (equivalent to no schedule)
+ *   <li>{@code timezone} omitted — system default timezone is used
+ * </ul>
+ *
+ * @param start the schedule start time, or {@code null} if no start restriction is configured
+ * @param end the schedule end time, or {@code null} if no end restriction is configured
+ * @param timezone the timezone used to evaluate start/end times, or {@code null} if the system
+ *     default timezone should be used
+ */
+public record Schedule(
+    @Nullable LocalDateTime start, @Nullable LocalDateTime end, @Nullable ZoneId timezone) {
+
+  public Schedule {
+    if (start != null && end != null && start.isAfter(end)) {
+      throw new IllegalArgumentException(
+          "Schedule start must not be after end, but start=" + start + " end=" + end);
+    }
+  }
+
+  /**
+   * Returns whether the schedule window is active at the given instant.
+   *
+   * @param now the current instant to check; must not be null
+   * @return {@code true} if {@code now} falls within the configured window, {@code false} otherwise
+   */
+  public boolean isActive(Instant now) {
+    ZoneId zone = timezone != null ? timezone : ZoneId.systemDefault();
+    LocalDateTime localNow = now.atZone(zone).toLocalDateTime();
+    if (start != null && localNow.isBefore(start)) return false;
+    if (end != null && localNow.isAfter(end)) return false;
+    return true;
+  }
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/provider/ScheduleProvider.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/provider/ScheduleProvider.java
@@ -1,0 +1,22 @@
+package net.brightroom.endpointgate.core.provider;
+
+import java.util.Optional;
+
+/**
+ * SPI for resolving the schedule configuration for a given endpoint gate.
+ *
+ * <p>Implementations provide the configured schedule for each gate. When a gate has no configured
+ * schedule, {@link Optional#empty()} is returned and the caller treats the schedule as always
+ * active.
+ */
+public interface ScheduleProvider {
+
+  /**
+   * Returns the configured schedule for the specified gate.
+   *
+   * @param gateId the identifier of the gate
+   * @return an {@link Optional} containing the {@link Schedule}, or {@link Optional#empty()} if no
+   *     schedule is configured for this gate
+   */
+  Optional<Schedule> getSchedule(String gateId);
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/rollout/DefaultRolloutStrategy.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/rollout/DefaultRolloutStrategy.java
@@ -1,0 +1,44 @@
+package net.brightroom.endpointgate.core.rollout;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import net.brightroom.endpointgate.core.context.EndpointGateContext;
+
+/**
+ * Default rollout strategy using SHA-256 hash bucketing.
+ *
+ * <p>Computes a bucket number (0–99) from the SHA-256 hash of {@code gateId:userIdentifier}. The
+ * bucket is compared with the rollout percentage to determine inclusion. The same input always
+ * produces the same bucket (deterministic), so sticky rollout is achieved when the caller provides
+ * a stable {@code userIdentifier}.
+ */
+public class DefaultRolloutStrategy implements RolloutStrategy {
+
+  /** Creates a new {@code DefaultRolloutStrategy}. */
+  public DefaultRolloutStrategy() {}
+
+  @Override
+  public boolean isInRollout(String gateId, EndpointGateContext context, int percentage) {
+    if (percentage <= 0) return false;
+    if (percentage >= 100) return true;
+    int bucket = calculateBucket(gateId, context.userIdentifier());
+    return bucket < percentage;
+  }
+
+  private int calculateBucket(String gateId, String userIdentifier) {
+    String key = gateId + ":" + userIdentifier;
+    try {
+      MessageDigest md = MessageDigest.getInstance("SHA-256");
+      byte[] hash = md.digest(key.getBytes(StandardCharsets.UTF_8));
+      int value =
+          ((hash[0] & 0xFF) << 24)
+              | ((hash[1] & 0xFF) << 16)
+              | ((hash[2] & 0xFF) << 8)
+              | (hash[3] & 0xFF);
+      return Integer.remainderUnsigned(value, 100);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 not available", e);
+    }
+  }
+}

--- a/core/src/main/java/net/brightroom/endpointgate/core/rollout/RolloutStrategy.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/rollout/RolloutStrategy.java
@@ -1,0 +1,22 @@
+package net.brightroom.endpointgate.core.rollout;
+
+import net.brightroom.endpointgate.core.context.EndpointGateContext;
+
+/**
+ * Strategy for determining whether a given context is within the rollout bucket.
+ *
+ * <p>Implementations receive the gate identifier, context, and rollout percentage, and return
+ * whether the request/user should be included in the rollout.
+ */
+public interface RolloutStrategy {
+
+  /**
+   * Determines whether the given context should be included in the rollout.
+   *
+   * @param gateId the gate identifier
+   * @param context the context containing the user/request identifier
+   * @param percentage the rollout percentage (0–100)
+   * @return {@code true} if the context is within the rollout bucket
+   */
+  boolean isInRollout(String gateId, EndpointGateContext context, int percentage);
+}

--- a/core/src/test/java/net/brightroom/endpointgate/core/context/EndpointGateContextTest.java
+++ b/core/src/test/java/net/brightroom/endpointgate/core/context/EndpointGateContextTest.java
@@ -1,0 +1,37 @@
+package net.brightroom.endpointgate.core.context;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class EndpointGateContextTest {
+
+  @Test
+  void constructor_throwsNullPointerException_whenUserIdentifierIsNull() {
+    assertThatNullPointerException()
+        .isThrownBy(() -> new EndpointGateContext(null))
+        .withMessageContaining("userIdentifier");
+  }
+
+  @Test
+  void constructor_throwsIllegalArgumentException_whenUserIdentifierIsBlank() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> new EndpointGateContext("  "))
+        .withMessageContaining("userIdentifier");
+  }
+
+  @Test
+  void constructor_throwsIllegalArgumentException_whenUserIdentifierIsEmpty() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> new EndpointGateContext(""))
+        .withMessageContaining("userIdentifier");
+  }
+
+  @Test
+  void constructor_success_whenUserIdentifierIsValid() {
+    EndpointGateContext context = new EndpointGateContext("user-123");
+    assertEquals("user-123", context.userIdentifier());
+  }
+}

--- a/core/src/test/java/net/brightroom/endpointgate/core/evaluation/AccessDecisionTest.java
+++ b/core/src/test/java/net/brightroom/endpointgate/core/evaluation/AccessDecisionTest.java
@@ -1,0 +1,32 @@
+package net.brightroom.endpointgate.core.evaluation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import net.brightroom.endpointgate.core.evaluation.AccessDecision.DeniedReason;
+import org.junit.jupiter.api.Test;
+
+class AccessDecisionTest {
+
+  @Test
+  void allowed_returnsAllowedInstance() {
+    AccessDecision decision = AccessDecision.allowed();
+    assertThat(decision).isInstanceOf(AccessDecision.Allowed.class);
+  }
+
+  @Test
+  void denied_returnsDeniedInstanceWithGateIdAndReason() {
+    AccessDecision decision = AccessDecision.denied("my-gate", DeniedReason.DISABLED);
+    assertThat(decision).isInstanceOf(AccessDecision.Denied.class);
+    AccessDecision.Denied denied = (AccessDecision.Denied) decision;
+    assertThat(denied.gateId()).isEqualTo("my-gate");
+    assertThat(denied.reason()).isEqualTo(DeniedReason.DISABLED);
+  }
+
+  @Test
+  void denied_supportsAllReasons() {
+    for (DeniedReason reason : DeniedReason.values()) {
+      AccessDecision decision = AccessDecision.denied("gate", reason);
+      assertThat(((AccessDecision.Denied) decision).reason()).isEqualTo(reason);
+    }
+  }
+}

--- a/core/src/test/java/net/brightroom/endpointgate/core/evaluation/ConditionEvaluationStepTest.java
+++ b/core/src/test/java/net/brightroom/endpointgate/core/evaluation/ConditionEvaluationStepTest.java
@@ -1,0 +1,52 @@
+package net.brightroom.endpointgate.core.evaluation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import net.brightroom.endpointgate.core.condition.ConditionVariables;
+import net.brightroom.endpointgate.core.condition.ConditionVariablesBuilder;
+import net.brightroom.endpointgate.core.condition.EndpointGateConditionEvaluator;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision.DeniedReason;
+import org.junit.jupiter.api.Test;
+
+class ConditionEvaluationStepTest {
+
+  private static final ConditionVariables EMPTY_VARS = new ConditionVariablesBuilder().build();
+
+  private final EndpointGateConditionEvaluator evaluator =
+      mock(EndpointGateConditionEvaluator.class);
+  private final ConditionEvaluationStep step = new ConditionEvaluationStep(evaluator);
+
+  @Test
+  void evaluate_returnsEmpty_whenConditionIsEmpty() {
+    EvaluationContext ctx = new EvaluationContext("my-gate", "", 100, EMPTY_VARS, () -> null);
+    assertThat(step.evaluate(ctx)).isEmpty();
+    verifyNoInteractions(evaluator);
+  }
+
+  @Test
+  void evaluate_returnsEmpty_whenConditionPasses() {
+    when(evaluator.evaluate(eq("headers['X-Beta'] != null"), any())).thenReturn(true);
+    EvaluationContext ctx =
+        new EvaluationContext("my-gate", "headers['X-Beta'] != null", 100, EMPTY_VARS, () -> null);
+    assertThat(step.evaluate(ctx)).isEmpty();
+  }
+
+  @Test
+  void evaluate_returnsDenied_whenConditionFails() {
+    when(evaluator.evaluate(eq("headers['X-Beta'] != null"), any())).thenReturn(false);
+    EvaluationContext ctx =
+        new EvaluationContext("my-gate", "headers['X-Beta'] != null", 100, EMPTY_VARS, () -> null);
+
+    Optional<AccessDecision> result = step.evaluate(ctx);
+    assertThat(result).isPresent();
+    AccessDecision.Denied denied = (AccessDecision.Denied) result.get();
+    assertThat(denied.gateId()).isEqualTo("my-gate");
+    assertThat(denied.reason()).isEqualTo(DeniedReason.CONDITION_NOT_MET);
+  }
+}

--- a/core/src/test/java/net/brightroom/endpointgate/core/evaluation/EnabledEvaluationStepTest.java
+++ b/core/src/test/java/net/brightroom/endpointgate/core/evaluation/EnabledEvaluationStepTest.java
@@ -1,0 +1,40 @@
+package net.brightroom.endpointgate.core.evaluation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import net.brightroom.endpointgate.core.condition.ConditionVariables;
+import net.brightroom.endpointgate.core.condition.ConditionVariablesBuilder;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision.DeniedReason;
+import net.brightroom.endpointgate.core.provider.EndpointGateProvider;
+import org.junit.jupiter.api.Test;
+
+class EnabledEvaluationStepTest {
+
+  private static final ConditionVariables EMPTY_VARS = new ConditionVariablesBuilder().build();
+  private static final EvaluationContext CTX =
+      new EvaluationContext("my-gate", "", 100, EMPTY_VARS, () -> null);
+
+  private final EndpointGateProvider provider = mock(EndpointGateProvider.class);
+  private final EnabledEvaluationStep step = new EnabledEvaluationStep(provider);
+
+  @Test
+  void evaluate_returnsEmpty_whenGateEnabled() {
+    when(provider.isGateEnabled("my-gate")).thenReturn(true);
+    Optional<AccessDecision> result = step.evaluate(CTX);
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void evaluate_returnsDenied_whenGateDisabled() {
+    when(provider.isGateEnabled("my-gate")).thenReturn(false);
+    Optional<AccessDecision> result = step.evaluate(CTX);
+    assertThat(result).isPresent();
+    assertThat(result.get()).isInstanceOf(AccessDecision.Denied.class);
+    AccessDecision.Denied denied = (AccessDecision.Denied) result.get();
+    assertThat(denied.gateId()).isEqualTo("my-gate");
+    assertThat(denied.reason()).isEqualTo(DeniedReason.DISABLED);
+  }
+}

--- a/core/src/test/java/net/brightroom/endpointgate/core/evaluation/EndpointGateEvaluationPipelineTest.java
+++ b/core/src/test/java/net/brightroom/endpointgate/core/evaluation/EndpointGateEvaluationPipelineTest.java
@@ -1,0 +1,80 @@
+package net.brightroom.endpointgate.core.evaluation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import net.brightroom.endpointgate.core.condition.ConditionVariables;
+import net.brightroom.endpointgate.core.condition.ConditionVariablesBuilder;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision.DeniedReason;
+import org.junit.jupiter.api.Test;
+
+class EndpointGateEvaluationPipelineTest {
+
+  private static final ConditionVariables EMPTY_VARS = new ConditionVariablesBuilder().build();
+  private static final EvaluationContext CTX =
+      new EvaluationContext("my-gate", "", 100, EMPTY_VARS, () -> null);
+
+  private final EnabledEvaluationStep enabledStep = mock(EnabledEvaluationStep.class);
+  private final ScheduleEvaluationStep scheduleStep = mock(ScheduleEvaluationStep.class);
+  private final ConditionEvaluationStep conditionStep = mock(ConditionEvaluationStep.class);
+  private final RolloutEvaluationStep rolloutStep = mock(RolloutEvaluationStep.class);
+
+  @Test
+  void evaluate_returnsAllowed_whenAllStepsPass() {
+    when(enabledStep.evaluate(any())).thenReturn(Optional.empty());
+    when(scheduleStep.evaluate(any())).thenReturn(Optional.empty());
+    when(conditionStep.evaluate(any())).thenReturn(Optional.empty());
+    when(rolloutStep.evaluate(any())).thenReturn(Optional.empty());
+
+    EndpointGateEvaluationPipeline pipeline =
+        new EndpointGateEvaluationPipeline(enabledStep, scheduleStep, conditionStep, rolloutStep);
+    assertThat(pipeline.evaluate(CTX)).isInstanceOf(AccessDecision.Allowed.class);
+  }
+
+  @Test
+  void evaluate_returnsFirstDenied_whenStepDenies() {
+    AccessDecision expectedDenial = AccessDecision.denied("my-gate", DeniedReason.DISABLED);
+    when(enabledStep.evaluate(any())).thenReturn(Optional.of(expectedDenial));
+
+    EndpointGateEvaluationPipeline pipeline =
+        new EndpointGateEvaluationPipeline(enabledStep, scheduleStep, conditionStep, rolloutStep);
+    assertThat(pipeline.evaluate(CTX)).isEqualTo(expectedDenial);
+  }
+
+  @Test
+  void evaluate_shortCircuits_afterFirstDenial() {
+    AccessDecision denial = AccessDecision.denied("my-gate", DeniedReason.DISABLED);
+    when(enabledStep.evaluate(any())).thenReturn(Optional.of(denial));
+
+    EndpointGateEvaluationPipeline pipeline =
+        new EndpointGateEvaluationPipeline(enabledStep, scheduleStep, conditionStep, rolloutStep);
+    pipeline.evaluate(CTX);
+
+    verify(scheduleStep, never()).evaluate(any());
+    verify(conditionStep, never()).evaluate(any());
+    verify(rolloutStep, never()).evaluate(any());
+  }
+
+  @Test
+  void evaluate_executesStepsInOrder_enabled_schedule_condition_rollout() {
+    when(enabledStep.evaluate(any())).thenReturn(Optional.empty());
+    when(scheduleStep.evaluate(any())).thenReturn(Optional.empty());
+    AccessDecision denial = AccessDecision.denied("my-gate", DeniedReason.CONDITION_NOT_MET);
+    when(conditionStep.evaluate(any())).thenReturn(Optional.of(denial));
+
+    EndpointGateEvaluationPipeline pipeline =
+        new EndpointGateEvaluationPipeline(enabledStep, scheduleStep, conditionStep, rolloutStep);
+    AccessDecision result = pipeline.evaluate(CTX);
+
+    assertThat(result).isEqualTo(denial);
+    verify(enabledStep).evaluate(any());
+    verify(scheduleStep).evaluate(any());
+    verify(conditionStep).evaluate(any());
+    verify(rolloutStep, never()).evaluate(any());
+  }
+}

--- a/core/src/test/java/net/brightroom/endpointgate/core/evaluation/RolloutEvaluationStepTest.java
+++ b/core/src/test/java/net/brightroom/endpointgate/core/evaluation/RolloutEvaluationStepTest.java
@@ -1,0 +1,56 @@
+package net.brightroom.endpointgate.core.evaluation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import net.brightroom.endpointgate.core.condition.ConditionVariables;
+import net.brightroom.endpointgate.core.condition.ConditionVariablesBuilder;
+import net.brightroom.endpointgate.core.context.EndpointGateContext;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision.DeniedReason;
+import net.brightroom.endpointgate.core.rollout.RolloutStrategy;
+import org.junit.jupiter.api.Test;
+
+class RolloutEvaluationStepTest {
+
+  private static final ConditionVariables EMPTY_VARS = new ConditionVariablesBuilder().build();
+  private static final EndpointGateContext CTX = new EndpointGateContext("user-1");
+
+  private final RolloutStrategy strategy = mock(RolloutStrategy.class);
+  private final RolloutEvaluationStep step = new RolloutEvaluationStep(strategy);
+
+  @Test
+  void evaluate_returnsEmpty_whenRolloutIs100() {
+    EvaluationContext ctx = new EvaluationContext("my-gate", "", 100, EMPTY_VARS, () -> CTX);
+    assertThat(step.evaluate(ctx)).isEmpty();
+    verifyNoInteractions(strategy);
+  }
+
+  @Test
+  void evaluate_returnsEmpty_whenGateContextIsNull_failOpen() {
+    EvaluationContext ctx = new EvaluationContext("my-gate", "", 50, EMPTY_VARS, () -> null);
+    assertThat(step.evaluate(ctx)).isEmpty();
+    verifyNoInteractions(strategy);
+  }
+
+  @Test
+  void evaluate_returnsEmpty_whenStrategyReturnsTrue() {
+    when(strategy.isInRollout("my-gate", CTX, 50)).thenReturn(true);
+    EvaluationContext ctx = new EvaluationContext("my-gate", "", 50, EMPTY_VARS, () -> CTX);
+    assertThat(step.evaluate(ctx)).isEmpty();
+  }
+
+  @Test
+  void evaluate_returnsDenied_whenStrategyReturnsFalse() {
+    when(strategy.isInRollout("my-gate", CTX, 50)).thenReturn(false);
+    EvaluationContext ctx = new EvaluationContext("my-gate", "", 50, EMPTY_VARS, () -> CTX);
+
+    Optional<AccessDecision> result = step.evaluate(ctx);
+    assertThat(result).isPresent();
+    AccessDecision.Denied denied = (AccessDecision.Denied) result.get();
+    assertThat(denied.gateId()).isEqualTo("my-gate");
+    assertThat(denied.reason()).isEqualTo(DeniedReason.ROLLOUT_EXCLUDED);
+  }
+}

--- a/core/src/test/java/net/brightroom/endpointgate/core/evaluation/ScheduleEvaluationStepTest.java
+++ b/core/src/test/java/net/brightroom/endpointgate/core/evaluation/ScheduleEvaluationStepTest.java
@@ -1,0 +1,70 @@
+package net.brightroom.endpointgate.core.evaluation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+import net.brightroom.endpointgate.core.condition.ConditionVariables;
+import net.brightroom.endpointgate.core.condition.ConditionVariablesBuilder;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision.DeniedReason;
+import net.brightroom.endpointgate.core.provider.Schedule;
+import net.brightroom.endpointgate.core.provider.ScheduleProvider;
+import org.junit.jupiter.api.Test;
+
+class ScheduleEvaluationStepTest {
+
+  private static final ConditionVariables EMPTY_VARS = new ConditionVariablesBuilder().build();
+  private static final EvaluationContext CTX =
+      new EvaluationContext("my-gate", "", 100, EMPTY_VARS, () -> null);
+
+  // Fixed clock at 2025-06-15T12:00:00Z
+  private static final Clock CLOCK =
+      Clock.fixed(Instant.parse("2025-06-15T12:00:00Z"), ZoneId.of("UTC"));
+
+  private final ScheduleProvider scheduleProvider = mock(ScheduleProvider.class);
+  private final ScheduleEvaluationStep step = new ScheduleEvaluationStep(scheduleProvider, CLOCK);
+
+  @Test
+  void evaluate_returnsEmpty_whenNoScheduleConfigured() {
+    when(scheduleProvider.getSchedule("my-gate")).thenReturn(Optional.empty());
+    assertThat(step.evaluate(CTX)).isEmpty();
+  }
+
+  @Test
+  void evaluate_returnsEmpty_whenScheduleIsActive() {
+    // start in past, no end → active
+    Schedule active = new Schedule(LocalDateTime.of(2025, 1, 1, 0, 0), null, ZoneId.of("UTC"));
+    when(scheduleProvider.getSchedule("my-gate")).thenReturn(Optional.of(active));
+    assertThat(step.evaluate(CTX)).isEmpty();
+  }
+
+  @Test
+  void evaluate_returnsDenied_whenScheduleIsInactive_endInPast() {
+    // end in past → inactive
+    Schedule inactive = new Schedule(null, LocalDateTime.of(2025, 1, 1, 0, 0), ZoneId.of("UTC"));
+    when(scheduleProvider.getSchedule("my-gate")).thenReturn(Optional.of(inactive));
+
+    Optional<AccessDecision> result = step.evaluate(CTX);
+    assertThat(result).isPresent();
+    AccessDecision.Denied denied = (AccessDecision.Denied) result.get();
+    assertThat(denied.gateId()).isEqualTo("my-gate");
+    assertThat(denied.reason()).isEqualTo(DeniedReason.SCHEDULE_INACTIVE);
+  }
+
+  @Test
+  void evaluate_returnsDenied_whenScheduleIsInactive_startInFuture() {
+    // start in future → inactive
+    Schedule inactive = new Schedule(LocalDateTime.of(2025, 12, 1, 0, 0), null, ZoneId.of("UTC"));
+    when(scheduleProvider.getSchedule("my-gate")).thenReturn(Optional.of(inactive));
+
+    Optional<AccessDecision> result = step.evaluate(CTX);
+    assertThat(result).isPresent();
+    assertThat(((AccessDecision.Denied) result.get()).reason())
+        .isEqualTo(DeniedReason.SCHEDULE_INACTIVE);
+  }
+}

--- a/core/src/test/java/net/brightroom/endpointgate/core/properties/GatePropertiesTest.java
+++ b/core/src/test/java/net/brightroom/endpointgate/core/properties/GatePropertiesTest.java
@@ -1,0 +1,35 @@
+package net.brightroom.endpointgate.core.properties;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class GatePropertiesTest {
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 50, 99, 100})
+  void setRollout_shouldAcceptValidValues(int rollout) {
+    GateProperties config = new GateProperties();
+    assertDoesNotThrow(() -> config.setRollout(rollout));
+    assertEquals(rollout, config.rollout());
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {-1, -100, 101, 200})
+  void setRollout_shouldRejectOutOfRangeValues(int rollout) {
+    GateProperties config = new GateProperties();
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> config.setRollout(rollout));
+    assertTrue(ex.getMessage().contains(String.valueOf(rollout)));
+  }
+
+  @Test
+  void setRollout_errorMessageShouldContainInvalidValue() {
+    GateProperties config = new GateProperties();
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> config.setRollout(101));
+    assertEquals("rollout must be between 0 and 100, but was: 101", ex.getMessage());
+  }
+}

--- a/core/src/test/java/net/brightroom/endpointgate/core/properties/SchedulePropertiesTest.java
+++ b/core/src/test/java/net/brightroom/endpointgate/core/properties/SchedulePropertiesTest.java
@@ -1,0 +1,120 @@
+package net.brightroom.endpointgate.core.properties;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class SchedulePropertiesTest {
+
+  private ScheduleProperties newSchedule() {
+    return new ScheduleProperties();
+  }
+
+  // --- setEnd() validation ---
+
+  @Test
+  void setEnd_throwsIllegalArgumentException_whenEndIsBeforeStart() {
+    ScheduleProperties schedule = newSchedule();
+    schedule.setStart(LocalDateTime.of(2026, 6, 15, 12, 0));
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> schedule.setEnd(LocalDateTime.of(2026, 6, 15, 11, 0)))
+        .withMessageContaining("schedule.end must not be before schedule.start");
+  }
+
+  @Test
+  void setEnd_doesNotThrow_whenEndEqualsStart() {
+    ScheduleProperties schedule = newSchedule();
+    schedule.setStart(LocalDateTime.of(2026, 6, 15, 12, 0));
+
+    assertThatNoException().isThrownBy(() -> schedule.setEnd(LocalDateTime.of(2026, 6, 15, 12, 0)));
+  }
+
+  @Test
+  void setEnd_doesNotThrow_whenEndIsAfterStart() {
+    ScheduleProperties schedule = newSchedule();
+    schedule.setStart(LocalDateTime.of(2026, 6, 15, 12, 0));
+
+    assertThatNoException().isThrownBy(() -> schedule.setEnd(LocalDateTime.of(2026, 6, 15, 13, 0)));
+  }
+
+  @Test
+  void setEnd_doesNotThrow_whenStartIsNull() {
+    ScheduleProperties schedule = newSchedule();
+
+    assertThatNoException().isThrownBy(() -> schedule.setEnd(LocalDateTime.of(2026, 6, 15, 11, 0)));
+  }
+
+  @Test
+  void setEnd_doesNotThrow_whenEndIsNull() {
+    ScheduleProperties schedule = newSchedule();
+    schedule.setStart(LocalDateTime.of(2026, 6, 15, 12, 0));
+
+    assertThatNoException().isThrownBy(() -> schedule.setEnd(null));
+  }
+
+  // --- setStart() validation ---
+
+  @Test
+  void setStart_throwsIllegalArgumentException_whenStartIsAfterEnd() {
+    ScheduleProperties schedule = newSchedule();
+    schedule.setEnd(LocalDateTime.of(2026, 6, 15, 12, 0));
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> schedule.setStart(LocalDateTime.of(2026, 6, 15, 13, 0)))
+        .withMessageContaining("schedule.start must not be after schedule.end");
+  }
+
+  @Test
+  void setStart_doesNotThrow_whenStartEqualsEnd() {
+    ScheduleProperties schedule = newSchedule();
+    schedule.setEnd(LocalDateTime.of(2026, 6, 15, 12, 0));
+
+    assertThatNoException()
+        .isThrownBy(() -> schedule.setStart(LocalDateTime.of(2026, 6, 15, 12, 0)));
+  }
+
+  @Test
+  void setStart_doesNotThrow_whenStartIsBeforeEnd() {
+    ScheduleProperties schedule = newSchedule();
+    schedule.setEnd(LocalDateTime.of(2026, 6, 15, 12, 0));
+
+    assertThatNoException()
+        .isThrownBy(() -> schedule.setStart(LocalDateTime.of(2026, 6, 15, 11, 0)));
+  }
+
+  @Test
+  void setStart_doesNotThrow_whenEndIsNull() {
+    ScheduleProperties schedule = newSchedule();
+
+    assertThatNoException()
+        .isThrownBy(() -> schedule.setStart(LocalDateTime.of(2026, 6, 15, 12, 0)));
+  }
+
+  @Test
+  void setStart_doesNotThrow_whenStartIsNull() {
+    ScheduleProperties schedule = newSchedule();
+    schedule.setEnd(LocalDateTime.of(2026, 6, 15, 12, 0));
+
+    assertThatNoException().isThrownBy(() -> schedule.setStart(null));
+  }
+
+  // --- toSchedule() ---
+
+  @Test
+  void toSchedule_returnsScheduleWithSameValues() {
+    ScheduleProperties config = newSchedule();
+    config.setStart(LocalDateTime.of(2026, 6, 15, 10, 0));
+    config.setEnd(LocalDateTime.of(2026, 6, 15, 18, 0));
+
+    var schedule = config.toSchedule();
+
+    assertEquals(LocalDateTime.of(2026, 6, 15, 10, 0), schedule.start());
+    assertEquals(LocalDateTime.of(2026, 6, 15, 18, 0), schedule.end());
+    assertNull(schedule.timezone());
+  }
+}

--- a/core/src/test/java/net/brightroom/endpointgate/core/provider/InMemoryEndpointGateProviderDefaultEnabledTest.java
+++ b/core/src/test/java/net/brightroom/endpointgate/core/provider/InMemoryEndpointGateProviderDefaultEnabledTest.java
@@ -1,0 +1,40 @@
+package net.brightroom.endpointgate.core.provider;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class InMemoryEndpointGateProviderDefaultEnabledTest {
+
+  @Test
+  void isGateEnabled_returnsFalse_whenGateIsUndefined_andDefaultEnabledIsFalse() {
+    var provider = new InMemoryEndpointGateProvider(Map.of("gate-a", true), false);
+    assertFalse(provider.isGateEnabled("undefined-gate"));
+  }
+
+  @Test
+  void isGateEnabled_returnsTrue_whenGateIsUndefined_andDefaultEnabledIsTrue() {
+    var provider = new InMemoryEndpointGateProvider(Map.of("gate-a", true), true);
+    assertTrue(provider.isGateEnabled("undefined-gate"));
+  }
+
+  @Test
+  void isGateEnabled_returnsTrue_whenGateIsExplicitlyEnabled_regardlessOfDefaultEnabled() {
+    var providerFailClosed = new InMemoryEndpointGateProvider(Map.of("gate-a", true), false);
+    var providerFailOpen = new InMemoryEndpointGateProvider(Map.of("gate-a", true), true);
+
+    assertTrue(providerFailClosed.isGateEnabled("gate-a"));
+    assertTrue(providerFailOpen.isGateEnabled("gate-a"));
+  }
+
+  @Test
+  void isGateEnabled_returnsFalse_whenGateIsExplicitlyDisabled_regardlessOfDefaultEnabled() {
+    var providerFailClosed = new InMemoryEndpointGateProvider(Map.of("gate-a", false), false);
+    var providerFailOpen = new InMemoryEndpointGateProvider(Map.of("gate-a", false), true);
+
+    assertFalse(providerFailClosed.isGateEnabled("gate-a"));
+    assertFalse(providerFailOpen.isGateEnabled("gate-a"));
+  }
+}

--- a/core/src/test/java/net/brightroom/endpointgate/core/provider/InMemoryScheduleProviderTest.java
+++ b/core/src/test/java/net/brightroom/endpointgate/core/provider/InMemoryScheduleProviderTest.java
@@ -1,0 +1,51 @@
+package net.brightroom.endpointgate.core.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class InMemoryScheduleProviderTest {
+
+  @Test
+  void getSchedule_returnsEmpty_whenGateNotPresent() {
+    var provider = new InMemoryScheduleProvider(Map.of());
+
+    assertTrue(provider.getSchedule("unknown").isEmpty());
+  }
+
+  @Test
+  void getSchedule_returnsSchedule_whenGatePresent() {
+    var schedule = new Schedule(LocalDateTime.of(2026, 1, 1, 0, 0), null, null);
+    var provider = new InMemoryScheduleProvider(Map.of("my-gate", schedule));
+
+    var result = provider.getSchedule("my-gate");
+
+    assertTrue(result.isPresent());
+    assertEquals(schedule, result.get());
+  }
+
+  @Test
+  void getSchedule_returnsEmpty_forOtherGate_whenOnlyOneConfigured() {
+    var schedule = new Schedule(null, LocalDateTime.of(2026, 12, 31, 23, 59), null);
+    var provider = new InMemoryScheduleProvider(Map.of("gate-a", schedule));
+
+    assertFalse(provider.getSchedule("gate-b").isPresent());
+  }
+
+  @Test
+  void constructor_makesDefensiveCopy_soExternalMapChangesAreIgnored() {
+    var schedule = new Schedule(LocalDateTime.of(2026, 1, 1, 0, 0), null, null);
+    var mutableMap = new java.util.HashMap<String, Schedule>();
+    mutableMap.put("gate-a", schedule);
+
+    var provider = new InMemoryScheduleProvider(mutableMap);
+    mutableMap.clear();
+
+    // The provider still returns the schedule despite the external map being cleared
+    assertTrue(provider.getSchedule("gate-a").isPresent());
+  }
+}

--- a/core/src/test/java/net/brightroom/endpointgate/core/provider/MutableInMemoryEndpointGateProviderTest.java
+++ b/core/src/test/java/net/brightroom/endpointgate/core/provider/MutableInMemoryEndpointGateProviderTest.java
@@ -1,0 +1,129 @@
+package net.brightroom.endpointgate.core.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Test;
+
+class MutableInMemoryEndpointGateProviderTest {
+
+  @Test
+  void isGateEnabled_returnsTrue_whenGateIsEnabled() {
+    var provider = new MutableInMemoryEndpointGateProvider(Map.of("gate-a", true), false);
+
+    assertTrue(provider.isGateEnabled("gate-a"));
+  }
+
+  @Test
+  void isGateEnabled_returnsFalse_whenGateIsDisabled() {
+    var provider = new MutableInMemoryEndpointGateProvider(Map.of("gate-a", false), true);
+
+    assertFalse(provider.isGateEnabled("gate-a"));
+  }
+
+  @Test
+  void isGateEnabled_returnsDefaultEnabled_false_whenGateIsUndefined() {
+    var provider = new MutableInMemoryEndpointGateProvider(Map.of(), false);
+
+    assertFalse(provider.isGateEnabled("undefined-gate"));
+  }
+
+  @Test
+  void isGateEnabled_returnsDefaultEnabled_true_whenGateIsUndefined() {
+    var provider = new MutableInMemoryEndpointGateProvider(Map.of(), true);
+
+    assertTrue(provider.isGateEnabled("undefined-gate"));
+  }
+
+  @Test
+  void getGates_returnsSnapshotOfAllGates() {
+    var provider =
+        new MutableInMemoryEndpointGateProvider(Map.of("gate-a", true, "gate-b", false), false);
+
+    var gates = provider.getGates();
+
+    assertEquals(Map.of("gate-a", true, "gate-b", false), gates);
+  }
+
+  @Test
+  void getGates_returnsImmutableCopy_notAffectedBySubsequentMutations() {
+    var provider = new MutableInMemoryEndpointGateProvider(Map.of("gate-a", true), false);
+    var snapshot = provider.getGates();
+
+    provider.setGateEnabled("gate-a", false);
+
+    assertTrue(snapshot.get("gate-a"), "snapshot must not reflect subsequent mutations");
+  }
+
+  @Test
+  void setGateEnabled_updatesExistingGate() {
+    var provider = new MutableInMemoryEndpointGateProvider(Map.of("gate-a", true), false);
+
+    provider.setGateEnabled("gate-a", false);
+
+    assertFalse(provider.isGateEnabled("gate-a"));
+  }
+
+  @Test
+  void setGateEnabled_addsNewGate() {
+    var provider = new MutableInMemoryEndpointGateProvider(Map.of(), false);
+
+    provider.setGateEnabled("new-gate", true);
+
+    assertTrue(provider.isGateEnabled("new-gate"));
+    assertEquals(Map.of("new-gate", true), provider.getGates());
+  }
+
+  @Test
+  void concurrentWrites_doNotCorruptState() {
+    var provider = new MutableInMemoryEndpointGateProvider(Map.of(), false);
+    int threadCount = 100;
+    List<String> gates = new ArrayList<>();
+    for (int i = 0; i < threadCount; i++) {
+      gates.add("gate-" + i);
+    }
+
+    try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      for (String gate : gates) {
+        executor.submit(() -> provider.setGateEnabled(gate, true));
+      }
+    }
+
+    assertEquals(threadCount, provider.getGates().size());
+    gates.forEach(gate -> assertTrue(provider.isGateEnabled(gate)));
+  }
+
+  @Test
+  void removeGate_removesExistingGate_andFallsBackToDefaultEnabled() {
+    var provider = new MutableInMemoryEndpointGateProvider(Map.of("gate-a", true), false);
+
+    provider.removeGate("gate-a");
+
+    assertFalse(provider.isGateEnabled("gate-a"));
+    assertTrue(provider.getGates().isEmpty());
+  }
+
+  @Test
+  void removeGate_fallsBackToDefaultEnabled_true_whenDefaultEnabledIsTrue() {
+    var provider = new MutableInMemoryEndpointGateProvider(Map.of("gate-a", false), true);
+
+    provider.removeGate("gate-a");
+
+    assertTrue(provider.isGateEnabled("gate-a"));
+  }
+
+  @Test
+  void removeGate_isNoOp_whenGateDoesNotExist() {
+    var provider = new MutableInMemoryEndpointGateProvider(Map.of("gate-a", true), false);
+
+    provider.removeGate("nonexistent");
+
+    assertEquals(Map.of("gate-a", true), provider.getGates());
+  }
+}

--- a/core/src/test/java/net/brightroom/endpointgate/core/provider/MutableInMemoryRolloutPercentageProviderTest.java
+++ b/core/src/test/java/net/brightroom/endpointgate/core/provider/MutableInMemoryRolloutPercentageProviderTest.java
@@ -1,0 +1,129 @@
+package net.brightroom.endpointgate.core.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class MutableInMemoryRolloutPercentageProviderTest {
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 50, 100})
+  void setRolloutPercentage_storesPercentage_whenValueIsValid(int percentage) {
+    var provider = new MutableInMemoryRolloutPercentageProvider(Map.of());
+
+    provider.setRolloutPercentage("gate-a", percentage);
+
+    assertEquals(OptionalInt.of(percentage), provider.getRolloutPercentage("gate-a"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {-1, 101})
+  void setRolloutPercentage_throwsIllegalArgumentException_whenValueIsOutOfRange(int percentage) {
+    var provider = new MutableInMemoryRolloutPercentageProvider(Map.of());
+
+    assertThrows(
+        IllegalArgumentException.class, () -> provider.setRolloutPercentage("gate-a", percentage));
+  }
+
+  @Test
+  void getRolloutPercentage_returnsPercentage_whenExists() {
+    var provider = new MutableInMemoryRolloutPercentageProvider(Map.of("gate-a", 50));
+
+    assertEquals(OptionalInt.of(50), provider.getRolloutPercentage("gate-a"));
+  }
+
+  @Test
+  void getRolloutPercentage_returnsEmpty_whenNotExists() {
+    var provider = new MutableInMemoryRolloutPercentageProvider(Map.of());
+
+    assertEquals(OptionalInt.empty(), provider.getRolloutPercentage("nonexistent"));
+  }
+
+  @Test
+  void setRolloutPercentage_addsNewEntry() {
+    var provider = new MutableInMemoryRolloutPercentageProvider(Map.of());
+
+    provider.setRolloutPercentage("gate-a", 75);
+
+    assertEquals(OptionalInt.of(75), provider.getRolloutPercentage("gate-a"));
+    assertEquals(Map.of("gate-a", 75), provider.getRolloutPercentages());
+  }
+
+  @Test
+  void setRolloutPercentage_updatesExistingEntry() {
+    var provider = new MutableInMemoryRolloutPercentageProvider(Map.of("gate-a", 50));
+
+    provider.setRolloutPercentage("gate-a", 80);
+
+    assertEquals(OptionalInt.of(80), provider.getRolloutPercentage("gate-a"));
+  }
+
+  @Test
+  void getRolloutPercentages_returnsSnapshotOfAllPercentages() {
+    var provider =
+        new MutableInMemoryRolloutPercentageProvider(Map.of("gate-a", 50, "gate-b", 100));
+
+    var percentages = provider.getRolloutPercentages();
+
+    assertEquals(Map.of("gate-a", 50, "gate-b", 100), percentages);
+  }
+
+  @Test
+  void getRolloutPercentages_returnsImmutableCopy_notAffectedBySubsequentMutations() {
+    var provider = new MutableInMemoryRolloutPercentageProvider(Map.of("gate-a", 50));
+    var snapshot = provider.getRolloutPercentages();
+
+    provider.setRolloutPercentage("gate-a", 80);
+
+    assertEquals(50, snapshot.get("gate-a"), "snapshot must not reflect subsequent mutations");
+  }
+
+  @Test
+  void concurrentSetRolloutPercentage_doesNotCorruptState() {
+    var provider = new MutableInMemoryRolloutPercentageProvider(Map.of());
+    int threadCount = 100;
+    List<String> gates = new ArrayList<>();
+    for (int i = 0; i < threadCount; i++) {
+      gates.add("gate-" + i);
+    }
+
+    try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      for (String gate : gates) {
+        executor.submit(() -> provider.setRolloutPercentage(gate, 50));
+      }
+    }
+
+    assertEquals(threadCount, provider.getRolloutPercentages().size());
+    gates.forEach(gate -> assertEquals(OptionalInt.of(50), provider.getRolloutPercentage(gate)));
+  }
+
+  @Test
+  void removeRolloutPercentage_removesExistingEntry() {
+    var provider = new MutableInMemoryRolloutPercentageProvider(Map.of("gate-a", 50));
+
+    provider.removeRolloutPercentage("gate-a");
+
+    assertEquals(OptionalInt.empty(), provider.getRolloutPercentage("gate-a"));
+    assertTrue(provider.getRolloutPercentages().isEmpty());
+  }
+
+  @Test
+  void removeRolloutPercentage_isNoOp_whenEntryDoesNotExist() {
+    var provider = new MutableInMemoryRolloutPercentageProvider(Map.of("gate-a", 50));
+
+    provider.removeRolloutPercentage("nonexistent");
+
+    assertEquals(OptionalInt.of(50), provider.getRolloutPercentage("gate-a"));
+    assertEquals(Map.of("gate-a", 50), provider.getRolloutPercentages());
+  }
+}

--- a/core/src/test/java/net/brightroom/endpointgate/core/provider/ScheduleTest.java
+++ b/core/src/test/java/net/brightroom/endpointgate/core/provider/ScheduleTest.java
@@ -1,0 +1,183 @@
+package net.brightroom.endpointgate.core.provider;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+
+class ScheduleTest {
+
+  // Fixed reference instant: 2026-06-15T12:00:00 UTC
+  private final Instant now = Instant.parse("2026-06-15T12:00:00Z");
+
+  // --- start only ---
+
+  @Test
+  void isActive_returnsFalse_whenNowIsBeforeStart() {
+    Schedule schedule = new Schedule(LocalDateTime.of(2026, 6, 15, 13, 0), null, ZoneId.of("UTC"));
+
+    assertFalse(schedule.isActive(now));
+  }
+
+  @Test
+  void isActive_returnsTrue_whenNowIsAfterStart() {
+    Schedule schedule = new Schedule(LocalDateTime.of(2026, 6, 15, 11, 0), null, ZoneId.of("UTC"));
+
+    assertTrue(schedule.isActive(now));
+  }
+
+  // --- end only ---
+
+  @Test
+  void isActive_returnsTrue_whenNowIsBeforeEnd() {
+    Schedule schedule = new Schedule(null, LocalDateTime.of(2026, 6, 15, 13, 0), ZoneId.of("UTC"));
+
+    assertTrue(schedule.isActive(now));
+  }
+
+  @Test
+  void isActive_returnsFalse_whenNowIsAfterEnd() {
+    Schedule schedule = new Schedule(null, LocalDateTime.of(2026, 6, 15, 11, 0), ZoneId.of("UTC"));
+
+    assertFalse(schedule.isActive(now));
+  }
+
+  // --- start + end ---
+
+  @Test
+  void isActive_returnsTrue_whenNowIsWithinRange() {
+    Schedule schedule =
+        new Schedule(
+            LocalDateTime.of(2026, 6, 15, 11, 0),
+            LocalDateTime.of(2026, 6, 15, 13, 0),
+            ZoneId.of("UTC"));
+
+    assertTrue(schedule.isActive(now));
+  }
+
+  @Test
+  void isActive_returnsFalse_whenNowIsBeforeRange() {
+    Schedule schedule =
+        new Schedule(
+            LocalDateTime.of(2026, 6, 15, 13, 0),
+            LocalDateTime.of(2026, 6, 15, 15, 0),
+            ZoneId.of("UTC"));
+
+    assertFalse(schedule.isActive(now));
+  }
+
+  @Test
+  void isActive_returnsFalse_whenNowIsAfterRange() {
+    Schedule schedule =
+        new Schedule(
+            LocalDateTime.of(2026, 6, 15, 9, 0),
+            LocalDateTime.of(2026, 6, 15, 11, 0),
+            ZoneId.of("UTC"));
+
+    assertFalse(schedule.isActive(now));
+  }
+
+  // --- neither start nor end ---
+
+  @Test
+  void isActive_returnsTrue_whenBothStartAndEndAreNull() {
+    Schedule schedule = new Schedule(null, null, null);
+
+    assertTrue(schedule.isActive(now));
+  }
+
+  // --- timezone ---
+
+  @Test
+  void isActive_appliesTimezone_whenTimezoneIsConfigured() {
+    Schedule schedule =
+        new Schedule(LocalDateTime.of(2026, 6, 15, 20, 0), null, ZoneId.of("Asia/Tokyo"));
+
+    assertTrue(schedule.isActive(now));
+  }
+
+  @Test
+  void isActive_returnsFalse_usingTimezone_whenBeforeStart() {
+    Schedule schedule =
+        new Schedule(LocalDateTime.of(2026, 6, 15, 22, 0), null, ZoneId.of("Asia/Tokyo"));
+
+    assertFalse(schedule.isActive(now));
+  }
+
+  @Test
+  void isActive_usesSystemDefaultTimezone_whenTimezoneIsNull() {
+    Schedule schedule = new Schedule(null, null, null);
+
+    assertTrue(schedule.isActive(now));
+  }
+
+  // --- boundary values ---
+
+  @Test
+  void isActive_returnsTrue_whenNowEqualsStart() {
+    Schedule schedule = new Schedule(LocalDateTime.of(2026, 6, 15, 12, 0), null, ZoneId.of("UTC"));
+
+    assertTrue(schedule.isActive(now));
+  }
+
+  @Test
+  void isActive_returnsTrue_whenNowEqualsEnd() {
+    Schedule schedule = new Schedule(null, LocalDateTime.of(2026, 6, 15, 12, 0), ZoneId.of("UTC"));
+
+    assertTrue(schedule.isActive(now));
+  }
+
+  // --- constructor validation ---
+
+  @Test
+  void constructor_throwsIllegalArgumentException_whenStartIsAfterEnd() {
+    assertThatIllegalArgumentException()
+        .isThrownBy(
+            () ->
+                new Schedule(
+                    LocalDateTime.of(2026, 6, 15, 13, 0),
+                    LocalDateTime.of(2026, 6, 15, 12, 0),
+                    ZoneId.of("UTC")))
+        .withMessageContaining("Schedule start must not be after end");
+  }
+
+  @Test
+  void constructor_doesNotThrow_whenStartEqualsEnd() {
+    assertThatNoException()
+        .isThrownBy(
+            () ->
+                new Schedule(
+                    LocalDateTime.of(2026, 6, 15, 12, 0),
+                    LocalDateTime.of(2026, 6, 15, 12, 0),
+                    ZoneId.of("UTC")));
+  }
+
+  @Test
+  void constructor_doesNotThrow_whenStartIsNull() {
+    assertThatNoException()
+        .isThrownBy(() -> new Schedule(null, LocalDateTime.of(2026, 6, 15, 12, 0), null));
+  }
+
+  @Test
+  void constructor_doesNotThrow_whenEndIsNull() {
+    assertThatNoException()
+        .isThrownBy(() -> new Schedule(LocalDateTime.of(2026, 6, 15, 12, 0), null, null));
+  }
+
+  // --- explicit UTC offset ---
+
+  @Test
+  void isActive_worksWithExplicitUtcOffset() {
+    Schedule schedule =
+        new Schedule(
+            LocalDateTime.of(2026, 6, 15, 8, 0), null, ZoneId.from(ZoneOffset.ofHours(-3)));
+
+    assertTrue(schedule.isActive(now));
+  }
+}

--- a/core/src/test/java/net/brightroom/endpointgate/core/rollout/DefaultRolloutStrategyTest.java
+++ b/core/src/test/java/net/brightroom/endpointgate/core/rollout/DefaultRolloutStrategyTest.java
@@ -1,0 +1,101 @@
+package net.brightroom.endpointgate.core.rollout;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+import net.brightroom.endpointgate.core.context.EndpointGateContext;
+import org.junit.jupiter.api.Test;
+
+class DefaultRolloutStrategyTest {
+
+  private final DefaultRolloutStrategy strategy = new DefaultRolloutStrategy();
+  private final EndpointGateContext context = new EndpointGateContext("user-1");
+
+  @Test
+  void isInRollout_returnsFalse_whenPercentageIsZero() {
+    assertFalse(strategy.isInRollout("gate", context, 0));
+  }
+
+  @Test
+  void isInRollout_returnsFalse_whenPercentageIsNegative() {
+    assertFalse(strategy.isInRollout("gate", context, -1));
+  }
+
+  @Test
+  void isInRollout_returnsTrue_whenPercentageIs100() {
+    assertTrue(strategy.isInRollout("gate", context, 100));
+  }
+
+  @Test
+  void isInRollout_returnsTrue_whenPercentageIsOver100() {
+    assertTrue(strategy.isInRollout("gate", context, 101));
+  }
+
+  @Test
+  void isInRollout_isDeterministic_sameInputAlwaysProducesSameResult() {
+    boolean first = strategy.isInRollout("gate", context, 50);
+    boolean second = strategy.isInRollout("gate", context, 50);
+    assertEquals(first, second);
+  }
+
+  @Test
+  void isInRollout_producesConsistentBucket_acrossMultipleGateIds() {
+    EndpointGateContext ctx = new EndpointGateContext("stable-user");
+    boolean resultA = strategy.isInRollout("gate-a", ctx, 50);
+    boolean resultB = strategy.isInRollout("gate-b", ctx, 50);
+
+    // Same user may have different buckets for different gates — just verify they're stable
+    assertEquals(resultA, strategy.isInRollout("gate-a", ctx, 50));
+    assertEquals(resultB, strategy.isInRollout("gate-b", ctx, 50));
+  }
+
+  @Test
+  void isInRollout_bucketsAreInValidRange() {
+    Set<Boolean> results = new HashSet<>();
+    for (int i = 0; i < 200; i++) {
+      EndpointGateContext ctx = new EndpointGateContext("user-" + i);
+      results.add(strategy.isInRollout("gate", ctx, 50));
+    }
+    assertTrue(results.contains(true));
+    assertTrue(results.contains(false));
+  }
+
+  @Test
+  void isInRollout_doesNotThrow_forInputsThatMightProduceExtremeHashValues() {
+    assertDoesNotThrow(
+        () -> {
+          for (int i = 0; i < 1000; i++) {
+            EndpointGateContext ctx = new EndpointGateContext("probe-" + i);
+            strategy.isInRollout("gate", ctx, 50);
+          }
+        });
+  }
+
+  @Test
+  void isInRollout_returnsTrue_whenPercentageIs99_andBucketIsWithinRange() {
+    int inRollout = 0;
+    for (int i = 0; i < 100; i++) {
+      EndpointGateContext ctx = new EndpointGateContext("user-" + i);
+      if (strategy.isInRollout("gate", ctx, 99)) {
+        inRollout++;
+      }
+    }
+    assertTrue(inRollout > 80, "Expected more than 80% in rollout at 99%, got: " + inRollout);
+  }
+
+  @Test
+  void isInRollout_returnsTrue_whenPercentageIs1_andBucketIsWithinRange() {
+    int inRollout = 0;
+    for (int i = 0; i < 100; i++) {
+      EndpointGateContext ctx = new EndpointGateContext("user-" + i);
+      if (strategy.isInRollout("gate", ctx, 1)) {
+        inRollout++;
+      }
+    }
+    assertTrue(inRollout < 20, "Expected fewer than 20% in rollout at 1%, got: " + inRollout);
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 java = "25"
 junit = "5.12.2"
+mockito = "5.18.0"
 reactor = "2025.0.3"
 
 [libraries]
@@ -32,6 +33,9 @@ junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 assertj-core = { module = "org.assertj:assertj-core", version = { strictly = "3.27.3" } }
+jspecify = { module = "org.jspecify:jspecify", version = { strictly = "1.0.0" } }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 jsoup = { module = "org.jsoup:jsoup", version = { strictly = "1.22.1" } }
 
 #########################################


### PR DESCRIPTION
## Summary

- Migrate and rename 36 main sources + 15 test files from `feature-flag-spring-boot-starter` core to `endpoint-gate` core
- All classes are Pure Java / JDK only — no Spring or Reactor dependencies
- Package: `net.brightroom.featureflag.core` → `net.brightroom.endpointgate.core`
- Class renames: `@FeatureFlag` → `@EndpointGate`, `FeatureFlagProvider` → `EndpointGateProvider`, `FeatureProperties` → `GateProperties`, etc.
- Field renames: `featureName` → `gateId` throughout
- `@Order` removed from evaluation steps; `EndpointGateEvaluationPipeline` hardcodes step order (Enabled → Schedule → Condition → Rollout)
- `ConditionVariables` converted from record to final class with package-private constructor (Builder-only instantiation)
- Redundant `PlainTextResponseBuilder` removed
- Added jspecify, mockito, assertj to version catalog and core dependencies

## Test plan

- [x] `./gradlew :core:check` passes (Spotless + compile + all unit tests)
- [x] Verify no Spring/Reactor imports exist in core module
- [x] Confirm downstream modules (`reactive-core`, `spring:core`) can depend on `core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)