### PR TITLE
Close #8 Implement reactive-core module (Reactor-dependent classes)

### DIFF
--- a/reactive-core/build.gradle.kts
+++ b/reactive-core/build.gradle.kts
@@ -9,4 +9,6 @@ dependencies {
     implementation(platform(libs.reactor.bom))
     implementation(libs.reactor.core)
     testImplementation(libs.reactor.test)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.junit.jupiter)
 }

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/condition/ReactiveEndpointGateConditionEvaluator.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/condition/ReactiveEndpointGateConditionEvaluator.java
@@ -1,0 +1,35 @@
+package net.brightroom.endpointgate.reactive.core.condition;
+
+import net.brightroom.endpointgate.core.condition.ConditionVariables;
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive SPI for evaluating condition expressions against request context variables.
+ *
+ * <p>Implementations evaluate an expression with the given variables and return a {@link
+ * Mono}{@code <Boolean>} indicating whether the condition is satisfied.
+ *
+ * <p>Register a custom bean to replace the default implementation:
+ *
+ * <pre>{@code
+ * @Bean
+ * ReactiveEndpointGateConditionEvaluator customEvaluator() {
+ *     return (expression, variables) -> ...;
+ * }
+ * }</pre>
+ *
+ * <p>Custom implementations that perform non-blocking I/O (e.g., querying a remote condition
+ * service) should return a {@link Mono} that executes on an appropriate scheduler and must not
+ * block the event loop thread.
+ */
+public interface ReactiveEndpointGateConditionEvaluator {
+
+  /**
+   * Evaluates a condition expression against the given variables.
+   *
+   * @param expression the expression to evaluate
+   * @param variables the variables available in the expression context
+   * @return a {@link Mono} emitting {@code true} if the condition is satisfied
+   */
+  Mono<Boolean> evaluate(String expression, ConditionVariables variables);
+}

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveConditionEvaluationStep.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveConditionEvaluationStep.java
@@ -1,0 +1,37 @@
+package net.brightroom.endpointgate.reactive.core.evaluation;
+
+import net.brightroom.endpointgate.core.evaluation.AccessDecision;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision.DeniedReason;
+import net.brightroom.endpointgate.core.evaluation.EvaluationContext;
+import net.brightroom.endpointgate.reactive.core.condition.ReactiveEndpointGateConditionEvaluator;
+import reactor.core.publisher.Mono;
+
+/** Reactive evaluation step that checks the condition expression. */
+public class ReactiveConditionEvaluationStep implements ReactiveEvaluationStep {
+
+  private final ReactiveEndpointGateConditionEvaluator conditionEvaluator;
+
+  /**
+   * Creates a new {@code ReactiveConditionEvaluationStep}.
+   *
+   * @param conditionEvaluator the reactive evaluator used to evaluate condition expressions
+   */
+  public ReactiveConditionEvaluationStep(
+      ReactiveEndpointGateConditionEvaluator conditionEvaluator) {
+    this.conditionEvaluator = conditionEvaluator;
+  }
+
+  @Override
+  public Mono<AccessDecision> evaluate(EvaluationContext context) {
+    if (context.condition().isEmpty()) {
+      return Mono.just(AccessDecision.allowed());
+    }
+    return conditionEvaluator
+        .evaluate(context.condition(), context.variables())
+        .map(
+            passed ->
+                passed
+                    ? AccessDecision.allowed()
+                    : AccessDecision.denied(context.gateId(), DeniedReason.CONDITION_NOT_MET));
+  }
+}

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveEnabledEvaluationStep.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveEnabledEvaluationStep.java
@@ -1,0 +1,34 @@
+package net.brightroom.endpointgate.reactive.core.evaluation;
+
+import net.brightroom.endpointgate.core.evaluation.AccessDecision;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision.DeniedReason;
+import net.brightroom.endpointgate.core.evaluation.EvaluationContext;
+import net.brightroom.endpointgate.reactive.core.provider.ReactiveEndpointGateProvider;
+import reactor.core.publisher.Mono;
+
+/** Reactive evaluation step that checks whether the gate is enabled. */
+public class ReactiveEnabledEvaluationStep implements ReactiveEvaluationStep {
+
+  private final ReactiveEndpointGateProvider provider;
+
+  /**
+   * Creates a new {@code ReactiveEnabledEvaluationStep}.
+   *
+   * @param provider the provider used to check whether a gate is enabled
+   */
+  public ReactiveEnabledEvaluationStep(ReactiveEndpointGateProvider provider) {
+    this.provider = provider;
+  }
+
+  @Override
+  public Mono<AccessDecision> evaluate(EvaluationContext context) {
+    return provider
+        .isGateEnabled(context.gateId())
+        .defaultIfEmpty(false)
+        .map(
+            enabled ->
+                enabled
+                    ? AccessDecision.allowed()
+                    : AccessDecision.denied(context.gateId(), DeniedReason.DISABLED));
+  }
+}

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveEndpointGateEvaluationPipeline.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveEndpointGateEvaluationPipeline.java
@@ -1,0 +1,65 @@
+package net.brightroom.endpointgate.reactive.core.evaluation;
+
+import net.brightroom.endpointgate.core.evaluation.AccessDecision;
+import net.brightroom.endpointgate.core.evaluation.EvaluationContext;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive endpoint gate evaluation pipeline.
+ *
+ * <p>Executes the four built-in {@link ReactiveEvaluationStep}s in a fixed order:
+ *
+ * <ol>
+ *   <li>{@link ReactiveEnabledEvaluationStep} — checks whether the gate is enabled
+ *   <li>{@link ReactiveScheduleEvaluationStep} — checks whether the schedule is active
+ *   <li>{@link ReactiveConditionEvaluationStep} — evaluates the condition expression
+ *   <li>{@link ReactiveRolloutEvaluationStep} — checks rollout bucket membership
+ * </ol>
+ *
+ * <p>Returns the first {@link AccessDecision.Denied} encountered, or {@link AccessDecision.Allowed}
+ * if all steps pass.
+ */
+public class ReactiveEndpointGateEvaluationPipeline {
+
+  private final ReactiveEnabledEvaluationStep enabledStep;
+  private final ReactiveScheduleEvaluationStep scheduleStep;
+  private final ReactiveConditionEvaluationStep conditionStep;
+  private final ReactiveRolloutEvaluationStep rolloutStep;
+
+  /**
+   * Creates a new {@code ReactiveEndpointGateEvaluationPipeline} with the fixed evaluation order.
+   *
+   * @param enabledStep the step that checks whether the gate is enabled
+   * @param scheduleStep the step that checks the schedule
+   * @param conditionStep the step that evaluates the condition expression
+   * @param rolloutStep the step that checks rollout bucket membership
+   */
+  public ReactiveEndpointGateEvaluationPipeline(
+      ReactiveEnabledEvaluationStep enabledStep,
+      ReactiveScheduleEvaluationStep scheduleStep,
+      ReactiveConditionEvaluationStep conditionStep,
+      ReactiveRolloutEvaluationStep rolloutStep) {
+    this.enabledStep = enabledStep;
+    this.scheduleStep = scheduleStep;
+    this.conditionStep = conditionStep;
+    this.rolloutStep = rolloutStep;
+  }
+
+  /**
+   * Evaluates all steps sequentially and returns the first denied decision or {@link
+   * AccessDecision#allowed()} if all steps pass.
+   *
+   * <p>Short-circuits on the first {@link AccessDecision.Denied} result.
+   *
+   * @param context the evaluation context
+   * @return a {@link Mono} emitting the access decision
+   */
+  public Mono<AccessDecision> evaluate(EvaluationContext context) {
+    return Flux.just(enabledStep, scheduleStep, conditionStep, rolloutStep)
+        .concatMap(step -> step.evaluate(context))
+        .filter(AccessDecision.Denied.class::isInstance)
+        .next()
+        .defaultIfEmpty(AccessDecision.allowed());
+  }
+}

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveEvaluationStep.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveEvaluationStep.java
@@ -1,0 +1,22 @@
+package net.brightroom.endpointgate.reactive.core.evaluation;
+
+import net.brightroom.endpointgate.core.evaluation.AccessDecision;
+import net.brightroom.endpointgate.core.evaluation.EvaluationContext;
+import reactor.core.publisher.Mono;
+
+/**
+ * SPI for a single step in the reactive endpoint gate evaluation pipeline.
+ *
+ * <p>Implement this interface to add a custom reactive evaluation step.
+ */
+public interface ReactiveEvaluationStep {
+
+  /**
+   * Evaluates one step of the reactive gate decision pipeline.
+   *
+   * @param context the evaluation context containing all inputs for this step
+   * @return a {@link Mono} emitting {@link AccessDecision.Allowed} if this step passes, or {@link
+   *     AccessDecision.Denied} if this step rejects the request
+   */
+  Mono<AccessDecision> evaluate(EvaluationContext context);
+}

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveRolloutEvaluationStep.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveRolloutEvaluationStep.java
@@ -1,0 +1,41 @@
+package net.brightroom.endpointgate.reactive.core.evaluation;
+
+import net.brightroom.endpointgate.core.context.EndpointGateContext;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision.DeniedReason;
+import net.brightroom.endpointgate.core.evaluation.EvaluationContext;
+import net.brightroom.endpointgate.reactive.core.rollout.ReactiveRolloutStrategy;
+import reactor.core.publisher.Mono;
+
+/** Reactive evaluation step that checks whether the request is within the rollout bucket. */
+public class ReactiveRolloutEvaluationStep implements ReactiveEvaluationStep {
+
+  private final ReactiveRolloutStrategy rolloutStrategy;
+
+  /**
+   * Creates a new {@code ReactiveRolloutEvaluationStep}.
+   *
+   * @param rolloutStrategy the strategy used to determine rollout bucket membership
+   */
+  public ReactiveRolloutEvaluationStep(ReactiveRolloutStrategy rolloutStrategy) {
+    this.rolloutStrategy = rolloutStrategy;
+  }
+
+  @Override
+  public Mono<AccessDecision> evaluate(EvaluationContext context) {
+    if (context.rolloutPercentage() >= 100) {
+      return Mono.just(AccessDecision.allowed());
+    }
+    EndpointGateContext gateContext = context.gateContextSupplier().get();
+    if (gateContext == null) {
+      return Mono.just(AccessDecision.allowed()); // fail-open: no context available
+    }
+    return rolloutStrategy
+        .isInRollout(context.gateId(), gateContext, context.rolloutPercentage())
+        .map(
+            inRollout ->
+                inRollout
+                    ? AccessDecision.allowed()
+                    : AccessDecision.denied(context.gateId(), DeniedReason.ROLLOUT_EXCLUDED));
+  }
+}

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveScheduleEvaluationStep.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveScheduleEvaluationStep.java
@@ -1,0 +1,38 @@
+package net.brightroom.endpointgate.reactive.core.evaluation;
+
+import java.time.Clock;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision.DeniedReason;
+import net.brightroom.endpointgate.core.evaluation.EvaluationContext;
+import net.brightroom.endpointgate.reactive.core.provider.ReactiveScheduleProvider;
+import reactor.core.publisher.Mono;
+
+/** Reactive evaluation step that checks whether the gate schedule is currently active. */
+public class ReactiveScheduleEvaluationStep implements ReactiveEvaluationStep {
+
+  private final ReactiveScheduleProvider scheduleProvider;
+  private final Clock clock;
+
+  /**
+   * Creates a new {@code ReactiveScheduleEvaluationStep}.
+   *
+   * @param scheduleProvider the provider used to look up the schedule per gate
+   * @param clock the clock used to obtain the current time for schedule evaluation
+   */
+  public ReactiveScheduleEvaluationStep(ReactiveScheduleProvider scheduleProvider, Clock clock) {
+    this.scheduleProvider = scheduleProvider;
+    this.clock = clock;
+  }
+
+  @Override
+  public Mono<AccessDecision> evaluate(EvaluationContext context) {
+    return scheduleProvider
+        .getSchedule(context.gateId())
+        .map(
+            schedule ->
+                schedule.isActive(clock.instant())
+                    ? AccessDecision.allowed()
+                    : AccessDecision.denied(context.gateId(), DeniedReason.SCHEDULE_INACTIVE))
+        .defaultIfEmpty(AccessDecision.allowed());
+  }
+}

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/InMemoryReactiveConditionProvider.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/InMemoryReactiveConditionProvider.java
@@ -1,0 +1,37 @@
+package net.brightroom.endpointgate.reactive.core.provider;
+
+import java.util.Map;
+import reactor.core.publisher.Mono;
+
+/**
+ * An implementation of {@link ReactiveConditionProvider} that stores condition expressions in
+ * memory using a {@link Map}.
+ *
+ * <p>This class provides a simple, immutable in-memory mechanism to resolve condition expressions
+ * reactively. When a gate has no configured condition, an empty {@link Mono} is returned.
+ */
+public class InMemoryReactiveConditionProvider implements ReactiveConditionProvider {
+
+  private final Map<String, String> conditions;
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Returns an empty {@link Mono} for gates not present in the conditions map.
+   */
+  @Override
+  public Mono<String> getCondition(String gateId) {
+    String condition = conditions.get(gateId);
+    return condition != null ? Mono.just(condition) : Mono.empty();
+  }
+
+  /**
+   * Constructs an instance with the provided condition expressions.
+   *
+   * @param conditions a map containing gate identifiers as keys and their condition expressions as
+   *     values; copied defensively on construction
+   */
+  public InMemoryReactiveConditionProvider(Map<String, String> conditions) {
+    this.conditions = Map.copyOf(conditions);
+  }
+}

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/InMemoryReactiveEndpointGateProvider.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/InMemoryReactiveEndpointGateProvider.java
@@ -1,0 +1,44 @@
+package net.brightroom.endpointgate.reactive.core.provider;
+
+import java.util.Map;
+import reactor.core.publisher.Mono;
+
+/**
+ * An implementation of {@link ReactiveEndpointGateProvider} that stores gate configurations in
+ * memory using a {@link Map}.
+ *
+ * <p>This class provides a simple, immutable in-memory mechanism to check whether specific gates
+ * are enabled or disabled reactively.
+ *
+ * <p><b>Fail-closed behavior (default):</b> If {@code gateId} is not present in the gate map, this
+ * provider returns the value of {@code defaultEnabled} (defaults to {@code false}).
+ */
+public class InMemoryReactiveEndpointGateProvider implements ReactiveEndpointGateProvider {
+
+  private final Map<String, Boolean> gates;
+  private final boolean defaultEnabled;
+
+  /**
+   * Returns whether the specified gate is enabled.
+   *
+   * @param gateId the identifier of the gate to check
+   * @return a {@link Mono} emitting {@code true} if the gate is enabled, {@code false} if disabled
+   *     or not configured
+   */
+  @Override
+  public Mono<Boolean> isGateEnabled(String gateId) {
+    return Mono.just(gates.getOrDefault(gateId, defaultEnabled));
+  }
+
+  /**
+   * Constructs an instance with the provided gates and default enabled status.
+   *
+   * @param gates a map containing gate identifiers as keys and their activation status as values;
+   *     copied defensively on construction
+   * @param defaultEnabled the default enabled status for gates not present in the map
+   */
+  public InMemoryReactiveEndpointGateProvider(Map<String, Boolean> gates, boolean defaultEnabled) {
+    this.gates = Map.copyOf(gates);
+    this.defaultEnabled = defaultEnabled;
+  }
+}

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/InMemoryReactiveRolloutPercentageProvider.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/InMemoryReactiveRolloutPercentageProvider.java
@@ -1,0 +1,38 @@
+package net.brightroom.endpointgate.reactive.core.provider;
+
+import java.util.Map;
+import reactor.core.publisher.Mono;
+
+/**
+ * An implementation of {@link ReactiveRolloutPercentageProvider} that stores rollout percentages in
+ * memory using a {@link Map}.
+ *
+ * <p>This class provides a simple, immutable in-memory mechanism to resolve rollout percentages
+ * reactively. When a gate has no configured rollout percentage, an empty {@link Mono} is returned.
+ */
+public class InMemoryReactiveRolloutPercentageProvider
+    implements ReactiveRolloutPercentageProvider {
+
+  private final Map<String, Integer> rolloutPercentages;
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Returns an empty {@link Mono} for gates not present in the rollout map.
+   */
+  @Override
+  public Mono<Integer> getRolloutPercentage(String gateId) {
+    Integer percentage = rolloutPercentages.get(gateId);
+    return percentage != null ? Mono.just(percentage) : Mono.empty();
+  }
+
+  /**
+   * Constructs an instance with the provided rollout percentages.
+   *
+   * @param rolloutPercentages a map containing gate identifiers as keys and their rollout
+   *     percentages as values; copied defensively on construction
+   */
+  public InMemoryReactiveRolloutPercentageProvider(Map<String, Integer> rolloutPercentages) {
+    this.rolloutPercentages = Map.copyOf(rolloutPercentages);
+  }
+}

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/InMemoryReactiveScheduleProvider.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/InMemoryReactiveScheduleProvider.java
@@ -1,0 +1,37 @@
+package net.brightroom.endpointgate.reactive.core.provider;
+
+import java.util.Map;
+import net.brightroom.endpointgate.core.provider.Schedule;
+import reactor.core.publisher.Mono;
+
+/**
+ * An implementation of {@link ReactiveScheduleProvider} that stores schedule configurations in
+ * memory using a {@link Map}.
+ *
+ * <p>This class provides a simple, immutable in-memory mechanism to resolve gate schedules
+ * reactively. When a gate has no configured schedule, an empty {@link Mono} is returned.
+ */
+public class InMemoryReactiveScheduleProvider implements ReactiveScheduleProvider {
+
+  private final Map<String, Schedule> schedules;
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Returns an empty {@link Mono} for gates not present in the schedule map.
+   */
+  @Override
+  public Mono<Schedule> getSchedule(String gateId) {
+    return Mono.justOrEmpty(schedules.get(gateId));
+  }
+
+  /**
+   * Constructs an instance with the provided schedule configurations.
+   *
+   * @param schedules a map containing gate identifiers as keys and their schedule configurations as
+   *     values; copied defensively on construction
+   */
+  public InMemoryReactiveScheduleProvider(Map<String, Schedule> schedules) {
+    this.schedules = Map.copyOf(schedules);
+  }
+}

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/MutableInMemoryReactiveConditionProvider.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/MutableInMemoryReactiveConditionProvider.java
@@ -1,0 +1,55 @@
+package net.brightroom.endpointgate.reactive.core.provider;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import reactor.core.publisher.Mono;
+
+/**
+ * A thread-safe, in-memory implementation of {@link MutableReactiveConditionProvider}.
+ *
+ * <p>Condition expressions are stored in a {@link ConcurrentHashMap}, allowing concurrent reads and
+ * writes without external synchronization.
+ */
+public class MutableInMemoryReactiveConditionProvider implements MutableReactiveConditionProvider {
+
+  private final ConcurrentHashMap<String, String> conditions;
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Returns an empty {@link Mono} for gates not present in the conditions map.
+   */
+  @Override
+  public Mono<String> getCondition(String gateId) {
+    String condition = conditions.get(gateId);
+    return condition != null ? Mono.just(condition) : Mono.empty();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Mono<Map<String, String>> getConditions() {
+    return Mono.just(Map.copyOf(conditions));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Mono<Void> setCondition(String gateId, String condition) {
+    return Mono.<Void>fromRunnable(() -> conditions.put(gateId, condition));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Mono<Boolean> removeCondition(String gateId) {
+    return Mono.fromCallable(() -> conditions.remove(gateId) != null);
+  }
+
+  /**
+   * Constructs a {@code MutableInMemoryReactiveConditionProvider} with the given initial condition
+   * expressions.
+   *
+   * @param conditions the initial condition expressions map; copied defensively on construction
+   */
+  public MutableInMemoryReactiveConditionProvider(Map<String, String> conditions) {
+    this.conditions = new ConcurrentHashMap<>(conditions);
+  }
+}

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/MutableInMemoryReactiveEndpointGateProvider.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/MutableInMemoryReactiveEndpointGateProvider.java
@@ -1,0 +1,61 @@
+package net.brightroom.endpointgate.reactive.core.provider;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import reactor.core.publisher.Mono;
+
+/**
+ * A thread-safe, in-memory implementation of {@link MutableReactiveEndpointGateProvider}.
+ *
+ * <p>Gates are stored in a {@link ConcurrentHashMap}, allowing concurrent reads and writes without
+ * external synchronization. The fail-closed/fail-open policy is controlled by {@code
+ * defaultEnabled}: when {@code false} (the default), unknown gates are treated as disabled.
+ */
+public class MutableInMemoryReactiveEndpointGateProvider
+    implements MutableReactiveEndpointGateProvider {
+
+  private final ConcurrentHashMap<String, Boolean> gates;
+  private final boolean defaultEnabled;
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Returns the value of {@code defaultEnabled} for gates not present in the map.
+   */
+  @Override
+  public Mono<Boolean> isGateEnabled(String gateId) {
+    return Mono.just(gates.getOrDefault(gateId, defaultEnabled));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Mono<Map<String, Boolean>> getGates() {
+    return Mono.just(Map.copyOf(gates));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Mono<Void> setGateEnabled(String gateId, boolean enabled) {
+    gates.put(gateId, enabled);
+    return Mono.empty();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Mono<Boolean> removeGate(String gateId) {
+    return Mono.just(gates.remove(gateId) != null);
+  }
+
+  /**
+   * Constructs a {@code MutableInMemoryReactiveEndpointGateProvider} with the given initial gates
+   * and default enabled state.
+   *
+   * @param gates the initial gate map; copied defensively on construction
+   * @param defaultEnabled the fallback value for gates not present in the map
+   */
+  public MutableInMemoryReactiveEndpointGateProvider(
+      Map<String, Boolean> gates, boolean defaultEnabled) {
+    this.gates = new ConcurrentHashMap<>(gates);
+    this.defaultEnabled = defaultEnabled;
+  }
+}

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/MutableInMemoryReactiveRolloutPercentageProvider.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/MutableInMemoryReactiveRolloutPercentageProvider.java
@@ -1,0 +1,61 @@
+package net.brightroom.endpointgate.reactive.core.provider;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import reactor.core.publisher.Mono;
+
+/**
+ * A thread-safe, in-memory implementation of {@link MutableReactiveRolloutPercentageProvider}.
+ *
+ * <p>Rollout percentages are stored in a {@link ConcurrentHashMap}, allowing concurrent reads and
+ * writes without external synchronization.
+ */
+public class MutableInMemoryReactiveRolloutPercentageProvider
+    implements MutableReactiveRolloutPercentageProvider {
+
+  private final ConcurrentHashMap<String, Integer> rolloutPercentages;
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Returns an empty {@link Mono} for gates not present in the rollout map.
+   */
+  @Override
+  public Mono<Integer> getRolloutPercentage(String gateId) {
+    Integer percentage = rolloutPercentages.get(gateId);
+    return percentage != null ? Mono.just(percentage) : Mono.empty();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Mono<Map<String, Integer>> getRolloutPercentages() {
+    return Mono.just(Map.copyOf(rolloutPercentages));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Mono<Void> setRolloutPercentage(String gateId, int percentage) {
+    if (percentage < 0 || percentage > 100) {
+      throw new IllegalArgumentException(
+          "percentage must be between 0 and 100, but was: " + percentage);
+    }
+    return Mono.<Void>fromRunnable(() -> rolloutPercentages.put(gateId, percentage));
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Mono<Boolean> removeRolloutPercentage(String gateId) {
+    return Mono.fromCallable(() -> rolloutPercentages.remove(gateId) != null);
+  }
+
+  /**
+   * Constructs a {@code MutableInMemoryReactiveRolloutPercentageProvider} with the given initial
+   * rollout percentages.
+   *
+   * @param rolloutPercentages the initial rollout percentage map; copied defensively on
+   *     construction
+   */
+  public MutableInMemoryReactiveRolloutPercentageProvider(Map<String, Integer> rolloutPercentages) {
+    this.rolloutPercentages = new ConcurrentHashMap<>(rolloutPercentages);
+  }
+}

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/MutableReactiveConditionProvider.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/MutableReactiveConditionProvider.java
@@ -1,0 +1,50 @@
+package net.brightroom.endpointgate.reactive.core.provider;
+
+import java.util.Map;
+import reactor.core.publisher.Mono;
+
+/**
+ * A reactive extension of {@link ReactiveConditionProvider} that supports dynamic mutation of
+ * condition expressions at runtime.
+ *
+ * <p>Implementations must be thread-safe, as conditions may be read and updated concurrently.
+ *
+ * <p>This interface serves as an SPI for the actuator endpoint to update condition expressions at
+ * runtime without restarting the application.
+ */
+public interface MutableReactiveConditionProvider extends ReactiveConditionProvider {
+
+  /**
+   * Returns a snapshot of all currently configured condition expressions.
+   *
+   * <p>The returned map must be an immutable copy; mutations to the returned map must not affect
+   * the provider's internal state.
+   *
+   * @return a {@link Mono} emitting an immutable map of gate identifiers to their condition
+   *     expressions
+   */
+  Mono<Map<String, String>> getConditions();
+
+  /**
+   * Updates the condition expression for the specified gate.
+   *
+   * <p>If the gate does not have a configured condition, it is created.
+   *
+   * @param gateId the identifier of the gate to update
+   * @param condition the new condition expression; must not be null
+   * @return a {@link Mono} that completes when the update is applied
+   */
+  Mono<Void> setCondition(String gateId, String condition);
+
+  /**
+   * Removes the condition expression for the specified gate.
+   *
+   * <p>If the gate does not have a configured condition, this method is a no-op and emits {@code
+   * false}.
+   *
+   * @param gateId the identifier of the gate whose condition to remove
+   * @return a {@link Mono} emitting {@code true} if the condition existed and was removed, {@code
+   *     false} if it did not exist
+   */
+  Mono<Boolean> removeCondition(String gateId);
+}

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/MutableReactiveEndpointGateProvider.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/MutableReactiveEndpointGateProvider.java
@@ -1,0 +1,58 @@
+package net.brightroom.endpointgate.reactive.core.provider;
+
+import java.util.Map;
+import reactor.core.publisher.Mono;
+
+/**
+ * A reactive extension of {@link ReactiveEndpointGateProvider} that supports dynamic mutation of
+ * gates at runtime.
+ *
+ * <p>Implementations must be thread-safe, as gates may be read and updated concurrently.
+ *
+ * <p>This interface serves as an SPI for external storage backends (e.g., Redis, databases) that
+ * need to expose mutable gate state in a reactive manner without depending on the {@code actuator}
+ * module.
+ */
+public interface MutableReactiveEndpointGateProvider extends ReactiveEndpointGateProvider {
+
+  /**
+   * Returns a snapshot of all currently configured gates and their enabled states.
+   *
+   * <p>The returned map must be an immutable copy; mutations to the returned map must not affect
+   * the provider's internal state.
+   *
+   * @return a {@link Mono} emitting an immutable map of gate identifiers to their enabled states
+   */
+  Mono<Map<String, Boolean>> getGates();
+
+  /**
+   * Updates the enabled state of the specified gate.
+   *
+   * <p>If the gate does not exist, it must be created with the given state.
+   *
+   * <p><b>Note:</b> This method does not publish {@code EndpointGateChangedEvent}. Event publishing
+   * is handled by the actuator endpoint. If you call this method directly and need event
+   * notification, publish the event manually via {@code ApplicationEventPublisher}.
+   *
+   * @param gateId the identifier of the gate to update
+   * @param enabled {@code true} to enable the gate, {@code false} to disable it
+   * @return a {@link Mono} that completes when the update is applied
+   */
+  Mono<Void> setGateEnabled(String gateId, boolean enabled);
+
+  /**
+   * Removes the specified gate from this provider.
+   *
+   * <p>After removal, {@link #isGateEnabled(String)} for this gate will return the default enabled
+   * value. If the gate does not exist, this method is a no-op and emits {@code false}.
+   *
+   * <p><b>Note:</b> This method does not publish {@code EndpointGateRemovedEvent}. Event publishing
+   * is handled by the actuator endpoint. If you call this method directly and need event
+   * notification, publish the event manually via {@code ApplicationEventPublisher}.
+   *
+   * @param gateId the identifier of the gate to remove
+   * @return a {@link Mono} emitting {@code true} if the gate existed and was removed, {@code false}
+   *     if it did not exist
+   */
+  Mono<Boolean> removeGate(String gateId);
+}

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/MutableReactiveRolloutPercentageProvider.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/MutableReactiveRolloutPercentageProvider.java
@@ -1,0 +1,52 @@
+package net.brightroom.endpointgate.reactive.core.provider;
+
+import java.util.Map;
+import reactor.core.publisher.Mono;
+
+/**
+ * A reactive extension of {@link ReactiveRolloutPercentageProvider} that supports dynamic mutation
+ * of rollout percentages at runtime.
+ *
+ * <p>Implementations must be thread-safe, as rollout percentages may be read and updated
+ * concurrently.
+ *
+ * <p>This interface serves as an SPI for the actuator endpoint to update rollout percentages at
+ * runtime without restarting the application.
+ */
+public interface MutableReactiveRolloutPercentageProvider
+    extends ReactiveRolloutPercentageProvider {
+
+  /**
+   * Returns a snapshot of all currently configured rollout percentages.
+   *
+   * <p>The returned map must be an immutable copy; mutations to the returned map must not affect
+   * the provider's internal state.
+   *
+   * @return a {@link Mono} emitting an immutable map of gate identifiers to their rollout
+   *     percentages
+   */
+  Mono<Map<String, Integer>> getRolloutPercentages();
+
+  /**
+   * Updates the rollout percentage for the specified gate.
+   *
+   * <p>If the gate does not have a configured rollout percentage, it is created.
+   *
+   * @param gateId the identifier of the gate to update
+   * @param percentage the new rollout percentage (0–100)
+   * @return a {@link Mono} that completes when the update is applied
+   */
+  Mono<Void> setRolloutPercentage(String gateId, int percentage);
+
+  /**
+   * Removes the rollout percentage for the specified gate.
+   *
+   * <p>If the gate does not have a configured rollout percentage, this method is a no-op and emits
+   * {@code false}.
+   *
+   * @param gateId the identifier of the gate whose rollout percentage to remove
+   * @return a {@link Mono} emitting {@code true} if the rollout percentage existed and was removed,
+   *     {@code false} if it did not exist
+   */
+  Mono<Boolean> removeRolloutPercentage(String gateId);
+}

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/ReactiveConditionProvider.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/ReactiveConditionProvider.java
@@ -1,0 +1,25 @@
+package net.brightroom.endpointgate.reactive.core.provider;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive SPI for resolving the condition expression for a given gate.
+ *
+ * <p>Implementations provide the configured condition expression for each gate. When a gate has no
+ * configured condition, an empty {@link Mono} is returned and the gate is treated as having no
+ * condition restriction.
+ *
+ * <p>Implement this interface and register it as a Spring bean to override the default in-memory
+ * provider. For example, to read conditions from a reactive data source.
+ */
+public interface ReactiveConditionProvider {
+
+  /**
+   * Returns the configured condition expression for the specified gate.
+   *
+   * @param gateId the identifier of the gate
+   * @return a {@link Mono} emitting the condition expression, or an empty {@link Mono} if no
+   *     condition is configured for this gate
+   */
+  Mono<String> getCondition(String gateId);
+}

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/ReactiveEndpointGateProvider.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/ReactiveEndpointGateProvider.java
@@ -1,0 +1,30 @@
+package net.brightroom.endpointgate.reactive.core.provider;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Provides a reactive mechanism to check the status of endpoint gates within an application.
+ *
+ * <p>The {@code ReactiveEndpointGateProvider} interface allows implementations to define how gates
+ * are stored and accessed in a non-blocking manner, enabling a consistent method for determining
+ * whether a specific gate is enabled or disabled at runtime.
+ *
+ * <p><b>Undefined gate policy:</b> Implementations must decide what to return when {@code gateId}
+ * is not known to the provider. The built-in {@link InMemoryReactiveEndpointGateProvider} uses a
+ * <em>fail-closed</em> policy by default (returns {@code false} for unknown gates), which can be
+ * changed to fail-open via {@code endpoint-gate.default-enabled: true}. Custom implementations
+ * should document their own policy clearly.
+ */
+public interface ReactiveEndpointGateProvider {
+
+  /**
+   * Determines whether a specific gate is enabled.
+   *
+   * <p>The return value for a gate identifier that is not managed by this provider is
+   * implementation-defined. See the implementing class for its undefined-gate policy.
+   *
+   * @param gateId the identifier of the gate whose status is to be verified
+   * @return a {@link Mono} emitting {@code true} if the gate is enabled, {@code false} otherwise
+   */
+  Mono<Boolean> isGateEnabled(String gateId);
+}

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/ReactiveRolloutPercentageProvider.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/ReactiveRolloutPercentageProvider.java
@@ -1,0 +1,25 @@
+package net.brightroom.endpointgate.reactive.core.provider;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive SPI for resolving the rollout percentage for a given gate.
+ *
+ * <p>Implementations provide the configured rollout percentage for each gate. When a gate has no
+ * configured rollout percentage, an empty {@link Mono} is returned and the caller falls back to the
+ * annotation's {@code rollout} attribute value.
+ *
+ * <p>Implement this interface and register it as a Spring bean to override the default in-memory
+ * provider. For example, to read rollout percentages from a reactive data source.
+ */
+public interface ReactiveRolloutPercentageProvider {
+
+  /**
+   * Returns the configured rollout percentage for the specified gate.
+   *
+   * @param gateId the identifier of the gate
+   * @return a {@link Mono} emitting the rollout percentage (0–100), or an empty {@link Mono} if no
+   *     rollout percentage is configured for this gate
+   */
+  Mono<Integer> getRolloutPercentage(String gateId);
+}

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/ReactiveScheduleProvider.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/ReactiveScheduleProvider.java
@@ -1,0 +1,25 @@
+package net.brightroom.endpointgate.reactive.core.provider;
+
+import net.brightroom.endpointgate.core.provider.Schedule;
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive SPI for resolving the schedule configuration for a given gate.
+ *
+ * <p>Implementations provide the configured schedule for each gate. When a gate has no configured
+ * schedule, an empty {@link Mono} is returned and the caller treats the schedule as always active.
+ *
+ * <p>Implement this interface and register it as a Spring bean to override the default in-memory
+ * provider. For example, to read schedules from a reactive data source.
+ */
+public interface ReactiveScheduleProvider {
+
+  /**
+   * Returns the configured schedule for the specified gate.
+   *
+   * @param gateId the identifier of the gate
+   * @return a {@link Mono} emitting the {@link Schedule}, or an empty {@link Mono} if no schedule
+   *     is configured for this gate
+   */
+  Mono<Schedule> getSchedule(String gateId);
+}

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/rollout/DefaultReactiveRolloutStrategy.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/rollout/DefaultReactiveRolloutStrategy.java
@@ -1,0 +1,23 @@
+package net.brightroom.endpointgate.reactive.core.rollout;
+
+import net.brightroom.endpointgate.core.context.EndpointGateContext;
+import net.brightroom.endpointgate.core.rollout.DefaultRolloutStrategy;
+import reactor.core.publisher.Mono;
+
+/**
+ * Default {@link ReactiveRolloutStrategy} that delegates to {@link DefaultRolloutStrategy}.
+ *
+ * <p>Wraps the synchronous SHA-256 hash bucketing logic in a non-blocking {@link Mono}.
+ */
+public class DefaultReactiveRolloutStrategy implements ReactiveRolloutStrategy {
+
+  /** Creates a new {@code DefaultReactiveRolloutStrategy}. */
+  public DefaultReactiveRolloutStrategy() {}
+
+  private final DefaultRolloutStrategy delegate = new DefaultRolloutStrategy();
+
+  @Override
+  public Mono<Boolean> isInRollout(String gateId, EndpointGateContext context, int percentage) {
+    return Mono.fromCallable(() -> delegate.isInRollout(gateId, context, percentage));
+  }
+}

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/rollout/ReactiveRolloutStrategy.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/rollout/ReactiveRolloutStrategy.java
@@ -1,0 +1,25 @@
+package net.brightroom.endpointgate.reactive.core.rollout;
+
+import net.brightroom.endpointgate.core.context.EndpointGateContext;
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive strategy for determining whether a given context is within the rollout bucket.
+ *
+ * <p>Implementations receive the gate identifier, context, and rollout percentage, and return a
+ * {@link Mono} that emits {@code true} if the request/user should be included in the rollout.
+ * Register a custom implementation as a {@code @Bean} to replace the default {@link
+ * DefaultReactiveRolloutStrategy}.
+ */
+public interface ReactiveRolloutStrategy {
+
+  /**
+   * Determines whether the given context should be included in the rollout.
+   *
+   * @param gateId the gate identifier
+   * @param context the context containing the user/request identifier
+   * @param percentage the rollout percentage (0–100)
+   * @return a {@link Mono} emitting {@code true} if the context is within the rollout bucket
+   */
+  Mono<Boolean> isInRollout(String gateId, EndpointGateContext context, int percentage);
+}

--- a/reactive-core/src/test/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveConditionEvaluationStepTest.java
+++ b/reactive-core/src/test/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveConditionEvaluationStepTest.java
@@ -1,0 +1,60 @@
+package net.brightroom.endpointgate.reactive.core.evaluation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import net.brightroom.endpointgate.core.condition.ConditionVariables;
+import net.brightroom.endpointgate.core.condition.ConditionVariablesBuilder;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision.DeniedReason;
+import net.brightroom.endpointgate.core.evaluation.EvaluationContext;
+import net.brightroom.endpointgate.reactive.core.condition.ReactiveEndpointGateConditionEvaluator;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class ReactiveConditionEvaluationStepTest {
+
+  private static final ConditionVariables EMPTY_VARS = new ConditionVariablesBuilder().build();
+
+  private final ReactiveEndpointGateConditionEvaluator evaluator =
+      mock(ReactiveEndpointGateConditionEvaluator.class);
+  private final ReactiveConditionEvaluationStep step =
+      new ReactiveConditionEvaluationStep(evaluator);
+
+  @Test
+  void evaluate_returnsAllowed_whenConditionIsEmpty() {
+    EvaluationContext ctx = new EvaluationContext("my-gate", "", 100, EMPTY_VARS, () -> null);
+    StepVerifier.create(step.evaluate(ctx))
+        .expectNextMatches(d -> d instanceof AccessDecision.Allowed)
+        .verifyComplete();
+    verifyNoInteractions(evaluator);
+  }
+
+  @Test
+  void evaluate_returnsAllowed_whenConditionPasses() {
+    when(evaluator.evaluate(eq("headers['X-Beta'] != null"), any())).thenReturn(Mono.just(true));
+    EvaluationContext ctx =
+        new EvaluationContext("my-gate", "headers['X-Beta'] != null", 100, EMPTY_VARS, () -> null);
+    StepVerifier.create(step.evaluate(ctx))
+        .expectNextMatches(d -> d instanceof AccessDecision.Allowed)
+        .verifyComplete();
+  }
+
+  @Test
+  void evaluate_returnsDenied_whenConditionFails() {
+    when(evaluator.evaluate(eq("headers['X-Beta'] != null"), any())).thenReturn(Mono.just(false));
+    EvaluationContext ctx =
+        new EvaluationContext("my-gate", "headers['X-Beta'] != null", 100, EMPTY_VARS, () -> null);
+    StepVerifier.create(step.evaluate(ctx))
+        .expectNextMatches(
+            d ->
+                d instanceof AccessDecision.Denied denied
+                    && denied.gateId().equals("my-gate")
+                    && denied.reason() == DeniedReason.CONDITION_NOT_MET)
+        .verifyComplete();
+  }
+}

--- a/reactive-core/src/test/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveEnabledEvaluationStepTest.java
+++ b/reactive-core/src/test/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveEnabledEvaluationStepTest.java
@@ -1,0 +1,55 @@
+package net.brightroom.endpointgate.reactive.core.evaluation;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import net.brightroom.endpointgate.core.condition.ConditionVariables;
+import net.brightroom.endpointgate.core.condition.ConditionVariablesBuilder;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision.DeniedReason;
+import net.brightroom.endpointgate.core.evaluation.EvaluationContext;
+import net.brightroom.endpointgate.reactive.core.provider.ReactiveEndpointGateProvider;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class ReactiveEnabledEvaluationStepTest {
+
+  private static final ConditionVariables EMPTY_VARS = new ConditionVariablesBuilder().build();
+  private static final EvaluationContext CTX =
+      new EvaluationContext("my-gate", "", 100, EMPTY_VARS, () -> null);
+
+  private final ReactiveEndpointGateProvider provider = mock(ReactiveEndpointGateProvider.class);
+  private final ReactiveEnabledEvaluationStep step = new ReactiveEnabledEvaluationStep(provider);
+
+  @Test
+  void evaluate_returnsAllowed_whenGateEnabled() {
+    when(provider.isGateEnabled("my-gate")).thenReturn(Mono.just(true));
+    StepVerifier.create(step.evaluate(CTX))
+        .expectNextMatches(d -> d instanceof AccessDecision.Allowed)
+        .verifyComplete();
+  }
+
+  @Test
+  void evaluate_returnsDenied_whenGateDisabled() {
+    when(provider.isGateEnabled("my-gate")).thenReturn(Mono.just(false));
+    StepVerifier.create(step.evaluate(CTX))
+        .expectNextMatches(
+            d ->
+                d instanceof AccessDecision.Denied denied
+                    && denied.gateId().equals("my-gate")
+                    && denied.reason() == DeniedReason.DISABLED)
+        .verifyComplete();
+  }
+
+  @Test
+  void evaluate_returnsDenied_whenProviderReturnsEmpty() {
+    when(provider.isGateEnabled("my-gate")).thenReturn(Mono.empty());
+    StepVerifier.create(step.evaluate(CTX))
+        .expectNextMatches(
+            d ->
+                d instanceof AccessDecision.Denied denied
+                    && denied.reason() == DeniedReason.DISABLED)
+        .verifyComplete();
+  }
+}

--- a/reactive-core/src/test/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveEndpointGateEvaluationPipelineTest.java
+++ b/reactive-core/src/test/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveEndpointGateEvaluationPipelineTest.java
@@ -1,0 +1,95 @@
+package net.brightroom.endpointgate.reactive.core.evaluation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import net.brightroom.endpointgate.core.condition.ConditionVariables;
+import net.brightroom.endpointgate.core.condition.ConditionVariablesBuilder;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision.DeniedReason;
+import net.brightroom.endpointgate.core.evaluation.EvaluationContext;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class ReactiveEndpointGateEvaluationPipelineTest {
+
+  private static final ConditionVariables EMPTY_VARS = new ConditionVariablesBuilder().build();
+  private static final EvaluationContext CTX =
+      new EvaluationContext("my-gate", "", 100, EMPTY_VARS, () -> null);
+
+  private ReactiveEndpointGateEvaluationPipeline pipelineAllAllowed() {
+    var enabledStep = mock(ReactiveEnabledEvaluationStep.class);
+    var scheduleStep = mock(ReactiveScheduleEvaluationStep.class);
+    var conditionStep = mock(ReactiveConditionEvaluationStep.class);
+    var rolloutStep = mock(ReactiveRolloutEvaluationStep.class);
+    when(enabledStep.evaluate(any())).thenReturn(Mono.just(AccessDecision.allowed()));
+    when(scheduleStep.evaluate(any())).thenReturn(Mono.just(AccessDecision.allowed()));
+    when(conditionStep.evaluate(any())).thenReturn(Mono.just(AccessDecision.allowed()));
+    when(rolloutStep.evaluate(any())).thenReturn(Mono.just(AccessDecision.allowed()));
+    return new ReactiveEndpointGateEvaluationPipeline(
+        enabledStep, scheduleStep, conditionStep, rolloutStep);
+  }
+
+  @Test
+  void evaluate_returnsAllowed_whenAllStepsPass() {
+    StepVerifier.create(pipelineAllAllowed().evaluate(CTX))
+        .expectNextMatches(d -> d instanceof AccessDecision.Allowed)
+        .verifyComplete();
+  }
+
+  @Test
+  void evaluate_returnsFirstDenied_whenEnabledStepDenies() {
+    AccessDecision denial = AccessDecision.denied("my-gate", DeniedReason.DISABLED);
+    var enabledStep = mock(ReactiveEnabledEvaluationStep.class);
+    var scheduleStep = mock(ReactiveScheduleEvaluationStep.class);
+    var conditionStep = mock(ReactiveConditionEvaluationStep.class);
+    var rolloutStep = mock(ReactiveRolloutEvaluationStep.class);
+    when(enabledStep.evaluate(any())).thenReturn(Mono.just(denial));
+    when(scheduleStep.evaluate(any())).thenReturn(Mono.just(AccessDecision.allowed()));
+    when(conditionStep.evaluate(any())).thenReturn(Mono.just(AccessDecision.allowed()));
+    when(rolloutStep.evaluate(any())).thenReturn(Mono.just(AccessDecision.allowed()));
+    var pipeline =
+        new ReactiveEndpointGateEvaluationPipeline(
+            enabledStep, scheduleStep, conditionStep, rolloutStep);
+
+    StepVerifier.create(pipeline.evaluate(CTX)).expectNext(denial).verifyComplete();
+  }
+
+  @Test
+  void evaluate_returnsFirstDenied_whenScheduleStepDenies() {
+    AccessDecision denial = AccessDecision.denied("my-gate", DeniedReason.SCHEDULE_INACTIVE);
+    var enabledStep = mock(ReactiveEnabledEvaluationStep.class);
+    var scheduleStep = mock(ReactiveScheduleEvaluationStep.class);
+    var conditionStep = mock(ReactiveConditionEvaluationStep.class);
+    var rolloutStep = mock(ReactiveRolloutEvaluationStep.class);
+    when(enabledStep.evaluate(any())).thenReturn(Mono.just(AccessDecision.allowed()));
+    when(scheduleStep.evaluate(any())).thenReturn(Mono.just(denial));
+    when(conditionStep.evaluate(any())).thenReturn(Mono.just(AccessDecision.allowed()));
+    when(rolloutStep.evaluate(any())).thenReturn(Mono.just(AccessDecision.allowed()));
+    var pipeline =
+        new ReactiveEndpointGateEvaluationPipeline(
+            enabledStep, scheduleStep, conditionStep, rolloutStep);
+
+    StepVerifier.create(pipeline.evaluate(CTX)).expectNext(denial).verifyComplete();
+  }
+
+  @Test
+  void evaluate_returnsFirstDenied_whenConditionStepDenies() {
+    AccessDecision denial = AccessDecision.denied("my-gate", DeniedReason.CONDITION_NOT_MET);
+    var enabledStep = mock(ReactiveEnabledEvaluationStep.class);
+    var scheduleStep = mock(ReactiveScheduleEvaluationStep.class);
+    var conditionStep = mock(ReactiveConditionEvaluationStep.class);
+    var rolloutStep = mock(ReactiveRolloutEvaluationStep.class);
+    when(enabledStep.evaluate(any())).thenReturn(Mono.just(AccessDecision.allowed()));
+    when(scheduleStep.evaluate(any())).thenReturn(Mono.just(AccessDecision.allowed()));
+    when(conditionStep.evaluate(any())).thenReturn(Mono.just(denial));
+    when(rolloutStep.evaluate(any())).thenReturn(Mono.just(AccessDecision.allowed()));
+    var pipeline =
+        new ReactiveEndpointGateEvaluationPipeline(
+            enabledStep, scheduleStep, conditionStep, rolloutStep);
+
+    StepVerifier.create(pipeline.evaluate(CTX)).expectNext(denial).verifyComplete();
+  }
+}

--- a/reactive-core/src/test/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveRolloutEvaluationStepTest.java
+++ b/reactive-core/src/test/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveRolloutEvaluationStepTest.java
@@ -1,0 +1,65 @@
+package net.brightroom.endpointgate.reactive.core.evaluation;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import net.brightroom.endpointgate.core.condition.ConditionVariables;
+import net.brightroom.endpointgate.core.condition.ConditionVariablesBuilder;
+import net.brightroom.endpointgate.core.context.EndpointGateContext;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision.DeniedReason;
+import net.brightroom.endpointgate.core.evaluation.EvaluationContext;
+import net.brightroom.endpointgate.reactive.core.rollout.ReactiveRolloutStrategy;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class ReactiveRolloutEvaluationStepTest {
+
+  private static final ConditionVariables EMPTY_VARS = new ConditionVariablesBuilder().build();
+  private static final EndpointGateContext GATE_CTX = new EndpointGateContext("user-1");
+
+  private final ReactiveRolloutStrategy strategy = mock(ReactiveRolloutStrategy.class);
+  private final ReactiveRolloutEvaluationStep step = new ReactiveRolloutEvaluationStep(strategy);
+
+  @Test
+  void evaluate_returnsAllowed_whenRolloutIs100() {
+    EvaluationContext ctx = new EvaluationContext("my-gate", "", 100, EMPTY_VARS, () -> GATE_CTX);
+    StepVerifier.create(step.evaluate(ctx))
+        .expectNextMatches(d -> d instanceof AccessDecision.Allowed)
+        .verifyComplete();
+    verifyNoInteractions(strategy);
+  }
+
+  @Test
+  void evaluate_returnsAllowed_whenGateContextIsNull_failOpen() {
+    EvaluationContext ctx = new EvaluationContext("my-gate", "", 50, EMPTY_VARS, () -> null);
+    StepVerifier.create(step.evaluate(ctx))
+        .expectNextMatches(d -> d instanceof AccessDecision.Allowed)
+        .verifyComplete();
+    verifyNoInteractions(strategy);
+  }
+
+  @Test
+  void evaluate_returnsAllowed_whenStrategyReturnsTrue() {
+    when(strategy.isInRollout("my-gate", GATE_CTX, 50)).thenReturn(Mono.just(true));
+    EvaluationContext ctx = new EvaluationContext("my-gate", "", 50, EMPTY_VARS, () -> GATE_CTX);
+    StepVerifier.create(step.evaluate(ctx))
+        .expectNextMatches(d -> d instanceof AccessDecision.Allowed)
+        .verifyComplete();
+  }
+
+  @Test
+  void evaluate_returnsDenied_whenStrategyReturnsFalse() {
+    when(strategy.isInRollout("my-gate", GATE_CTX, 50)).thenReturn(Mono.just(false));
+    EvaluationContext ctx = new EvaluationContext("my-gate", "", 50, EMPTY_VARS, () -> GATE_CTX);
+    StepVerifier.create(step.evaluate(ctx))
+        .expectNextMatches(
+            d ->
+                d instanceof AccessDecision.Denied denied
+                    && denied.gateId().equals("my-gate")
+                    && denied.reason() == DeniedReason.ROLLOUT_EXCLUDED)
+        .verifyComplete();
+  }
+}

--- a/reactive-core/src/test/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveScheduleEvaluationStepTest.java
+++ b/reactive-core/src/test/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveScheduleEvaluationStepTest.java
@@ -1,0 +1,79 @@
+package net.brightroom.endpointgate.reactive.core.evaluation;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import net.brightroom.endpointgate.core.condition.ConditionVariables;
+import net.brightroom.endpointgate.core.condition.ConditionVariablesBuilder;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision.DeniedReason;
+import net.brightroom.endpointgate.core.evaluation.EvaluationContext;
+import net.brightroom.endpointgate.core.provider.Schedule;
+import net.brightroom.endpointgate.reactive.core.provider.ReactiveScheduleProvider;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class ReactiveScheduleEvaluationStepTest {
+
+  private static final ConditionVariables EMPTY_VARS = new ConditionVariablesBuilder().build();
+  private static final EvaluationContext CTX =
+      new EvaluationContext("my-gate", "", 100, EMPTY_VARS, () -> null);
+
+  // Fixed clock at 2025-06-15T12:00:00Z
+  private static final Clock CLOCK =
+      Clock.fixed(Instant.parse("2025-06-15T12:00:00Z"), ZoneId.of("UTC"));
+
+  private final ReactiveScheduleProvider scheduleProvider = mock(ReactiveScheduleProvider.class);
+  private final ReactiveScheduleEvaluationStep step =
+      new ReactiveScheduleEvaluationStep(scheduleProvider, CLOCK);
+
+  @Test
+  void evaluate_returnsAllowed_whenNoScheduleConfigured() {
+    when(scheduleProvider.getSchedule("my-gate")).thenReturn(Mono.empty());
+    StepVerifier.create(step.evaluate(CTX))
+        .expectNextMatches(d -> d instanceof AccessDecision.Allowed)
+        .verifyComplete();
+  }
+
+  @Test
+  void evaluate_returnsAllowed_whenScheduleIsActive() {
+    // start in past, no end → active
+    Schedule active = new Schedule(LocalDateTime.of(2025, 1, 1, 0, 0), null, ZoneId.of("UTC"));
+    when(scheduleProvider.getSchedule("my-gate")).thenReturn(Mono.just(active));
+    StepVerifier.create(step.evaluate(CTX))
+        .expectNextMatches(d -> d instanceof AccessDecision.Allowed)
+        .verifyComplete();
+  }
+
+  @Test
+  void evaluate_returnsDenied_whenScheduleIsInactive_endInPast() {
+    // end in past → inactive
+    Schedule inactive = new Schedule(null, LocalDateTime.of(2025, 1, 1, 0, 0), ZoneId.of("UTC"));
+    when(scheduleProvider.getSchedule("my-gate")).thenReturn(Mono.just(inactive));
+    StepVerifier.create(step.evaluate(CTX))
+        .expectNextMatches(
+            d ->
+                d instanceof AccessDecision.Denied denied
+                    && denied.gateId().equals("my-gate")
+                    && denied.reason() == DeniedReason.SCHEDULE_INACTIVE)
+        .verifyComplete();
+  }
+
+  @Test
+  void evaluate_returnsDenied_whenScheduleIsInactive_startInFuture() {
+    // start in future → inactive
+    Schedule inactive = new Schedule(LocalDateTime.of(2025, 12, 1, 0, 0), null, ZoneId.of("UTC"));
+    when(scheduleProvider.getSchedule("my-gate")).thenReturn(Mono.just(inactive));
+    StepVerifier.create(step.evaluate(CTX))
+        .expectNextMatches(
+            d ->
+                d instanceof AccessDecision.Denied denied
+                    && denied.reason() == DeniedReason.SCHEDULE_INACTIVE)
+        .verifyComplete();
+  }
+}

--- a/reactive-core/src/test/java/net/brightroom/endpointgate/reactive/core/provider/InMemoryReactiveScheduleProviderTest.java
+++ b/reactive-core/src/test/java/net/brightroom/endpointgate/reactive/core/provider/InMemoryReactiveScheduleProviderTest.java
@@ -1,0 +1,53 @@
+package net.brightroom.endpointgate.reactive.core.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import net.brightroom.endpointgate.core.provider.Schedule;
+import org.junit.jupiter.api.Test;
+
+class InMemoryReactiveScheduleProviderTest {
+
+  @Test
+  void getSchedule_returnsEmpty_whenGateNotPresent() {
+    var provider = new InMemoryReactiveScheduleProvider(Map.of());
+
+    assertTrue(provider.getSchedule("unknown").blockOptional().isEmpty());
+  }
+
+  @Test
+  void getSchedule_returnsSchedule_whenGatePresent() {
+    var schedule = new Schedule(LocalDateTime.of(2026, 1, 1, 0, 0), null, null);
+    var provider = new InMemoryReactiveScheduleProvider(Map.of("my-gate", schedule));
+
+    var result = provider.getSchedule("my-gate").blockOptional();
+
+    assertTrue(result.isPresent());
+    assertEquals(schedule, result.get());
+  }
+
+  @Test
+  void getSchedule_returnsEmpty_forOtherGate_whenOnlyOneConfigured() {
+    var schedule = new Schedule(null, LocalDateTime.of(2026, 12, 31, 23, 59), null);
+    var provider = new InMemoryReactiveScheduleProvider(Map.of("gate-a", schedule));
+
+    assertFalse(provider.getSchedule("gate-b").blockOptional().isPresent());
+  }
+
+  @Test
+  void constructor_makesDefensiveCopy_soExternalMapChangesAreIgnored() {
+    var schedule = new Schedule(LocalDateTime.of(2026, 1, 1, 0, 0), null, null);
+    var mutableMap = new java.util.HashMap<String, Schedule>();
+    mutableMap.put("gate-a", schedule);
+
+    var provider = new InMemoryReactiveScheduleProvider(mutableMap);
+    mutableMap.clear();
+
+    var result = provider.getSchedule("gate-a").blockOptional();
+    assertTrue(result.isPresent());
+    assertEquals(schedule, result.get());
+  }
+}

--- a/reactive-core/src/test/java/net/brightroom/endpointgate/reactive/core/provider/MutableInMemoryReactiveEndpointGateProviderTest.java
+++ b/reactive-core/src/test/java/net/brightroom/endpointgate/reactive/core/provider/MutableInMemoryReactiveEndpointGateProviderTest.java
@@ -1,0 +1,129 @@
+package net.brightroom.endpointgate.reactive.core.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Test;
+
+class MutableInMemoryReactiveEndpointGateProviderTest {
+
+  @Test
+  void isGateEnabled_returnsTrue_whenGateIsEnabled() {
+    var provider = new MutableInMemoryReactiveEndpointGateProvider(Map.of("gate-a", true), false);
+
+    assertTrue(provider.isGateEnabled("gate-a").block());
+  }
+
+  @Test
+  void isGateEnabled_returnsFalse_whenGateIsDisabled() {
+    var provider = new MutableInMemoryReactiveEndpointGateProvider(Map.of("gate-a", false), true);
+
+    assertFalse(provider.isGateEnabled("gate-a").block());
+  }
+
+  @Test
+  void isGateEnabled_returnsDefaultEnabled_false_whenGateIsUndefined() {
+    var provider = new MutableInMemoryReactiveEndpointGateProvider(Map.of(), false);
+
+    assertFalse(provider.isGateEnabled("undefined-gate").block());
+  }
+
+  @Test
+  void isGateEnabled_returnsDefaultEnabled_true_whenGateIsUndefined() {
+    var provider = new MutableInMemoryReactiveEndpointGateProvider(Map.of(), true);
+
+    assertTrue(provider.isGateEnabled("undefined-gate").block());
+  }
+
+  @Test
+  void getGates_returnsSnapshotOfAllGates() {
+    var provider =
+        new MutableInMemoryReactiveEndpointGateProvider(
+            Map.of("gate-a", true, "gate-b", false), false);
+
+    assertEquals(Map.of("gate-a", true, "gate-b", false), provider.getGates().block());
+  }
+
+  @Test
+  void getGates_returnsImmutableCopy_notAffectedBySubsequentMutations() {
+    var provider = new MutableInMemoryReactiveEndpointGateProvider(Map.of("gate-a", true), false);
+    var snapshot = provider.getGates().block();
+
+    provider.setGateEnabled("gate-a", false).block();
+
+    assertTrue(snapshot.get("gate-a"), "snapshot must not reflect subsequent mutations");
+  }
+
+  @Test
+  void setGateEnabled_updatesExistingGate() {
+    var provider = new MutableInMemoryReactiveEndpointGateProvider(Map.of("gate-a", true), false);
+
+    provider.setGateEnabled("gate-a", false).block();
+
+    assertFalse(provider.isGateEnabled("gate-a").block());
+  }
+
+  @Test
+  void setGateEnabled_addsNewGate() {
+    var provider = new MutableInMemoryReactiveEndpointGateProvider(Map.of(), false);
+
+    provider.setGateEnabled("new-gate", true).block();
+
+    assertTrue(provider.isGateEnabled("new-gate").block());
+    assertEquals(Map.of("new-gate", true), provider.getGates().block());
+  }
+
+  @Test
+  void concurrentWrites_doNotCorruptState() {
+    var provider = new MutableInMemoryReactiveEndpointGateProvider(Map.of(), false);
+    int threadCount = 100;
+    List<String> gates = new ArrayList<>();
+    for (int i = 0; i < threadCount; i++) {
+      gates.add("gate-" + i);
+    }
+
+    try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      for (String gate : gates) {
+        executor.submit(() -> provider.setGateEnabled(gate, true).block());
+      }
+    }
+
+    var gateMap = provider.getGates().block();
+    assertEquals(threadCount, gateMap.size());
+    gates.forEach(gate -> assertTrue(provider.isGateEnabled(gate).block()));
+  }
+
+  @Test
+  void removeGate_removesExistingGate_andFallsBackToDefaultEnabled() {
+    var provider = new MutableInMemoryReactiveEndpointGateProvider(Map.of("gate-a", true), false);
+
+    provider.removeGate("gate-a").block();
+
+    assertFalse(provider.isGateEnabled("gate-a").block());
+    assertTrue(provider.getGates().block().isEmpty());
+  }
+
+  @Test
+  void removeGate_fallsBackToDefaultEnabled_true_whenDefaultEnabledIsTrue() {
+    var provider = new MutableInMemoryReactiveEndpointGateProvider(Map.of("gate-a", false), true);
+
+    provider.removeGate("gate-a").block();
+
+    assertTrue(provider.isGateEnabled("gate-a").block());
+  }
+
+  @Test
+  void removeGate_isNoOp_whenGateDoesNotExist() {
+    var provider = new MutableInMemoryReactiveEndpointGateProvider(Map.of("gate-a", true), false);
+
+    provider.removeGate("nonexistent").block();
+
+    assertEquals(Map.of("gate-a", true), provider.getGates().block());
+  }
+}

--- a/reactive-core/src/test/java/net/brightroom/endpointgate/reactive/core/provider/MutableInMemoryReactiveRolloutPercentageProviderTest.java
+++ b/reactive-core/src/test/java/net/brightroom/endpointgate/reactive/core/provider/MutableInMemoryReactiveRolloutPercentageProviderTest.java
@@ -1,0 +1,132 @@
+package net.brightroom.endpointgate.reactive.core.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class MutableInMemoryReactiveRolloutPercentageProviderTest {
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 50, 100})
+  void setRolloutPercentage_storesPercentage_whenValueIsValid(int percentage) {
+    var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of());
+
+    provider.setRolloutPercentage("gate-a", percentage).block();
+
+    assertEquals(percentage, provider.getRolloutPercentage("gate-a").block());
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {-1, 101})
+  void setRolloutPercentage_throwsIllegalArgumentException_whenValueIsOutOfRange(int percentage) {
+    var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of());
+
+    assertThrows(
+        IllegalArgumentException.class, () -> provider.setRolloutPercentage("gate-a", percentage));
+  }
+
+  @Test
+  void getRolloutPercentage_returnsPercentage_whenExists() {
+    var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of("gate-a", 50));
+
+    assertEquals(50, provider.getRolloutPercentage("gate-a").block());
+  }
+
+  @Test
+  void getRolloutPercentage_returnsEmpty_whenNotExists() {
+    var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of());
+
+    assertNull(provider.getRolloutPercentage("nonexistent").block());
+  }
+
+  @Test
+  void setRolloutPercentage_addsNewEntry() {
+    var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of());
+
+    provider.setRolloutPercentage("gate-a", 75).block();
+
+    assertEquals(75, provider.getRolloutPercentage("gate-a").block());
+    assertEquals(Map.of("gate-a", 75), provider.getRolloutPercentages().block());
+  }
+
+  @Test
+  void setRolloutPercentage_updatesExistingEntry() {
+    var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of("gate-a", 50));
+
+    provider.setRolloutPercentage("gate-a", 80).block();
+
+    assertEquals(80, provider.getRolloutPercentage("gate-a").block());
+  }
+
+  @Test
+  void getRolloutPercentages_returnsSnapshotOfAllPercentages() {
+    var provider =
+        new MutableInMemoryReactiveRolloutPercentageProvider(Map.of("gate-a", 50, "gate-b", 100));
+
+    var percentages = provider.getRolloutPercentages().block();
+
+    assertEquals(Map.of("gate-a", 50, "gate-b", 100), percentages);
+  }
+
+  @Test
+  void getRolloutPercentages_returnsImmutableCopy_notAffectedBySubsequentMutations() {
+    var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of("gate-a", 50));
+    var snapshot = provider.getRolloutPercentages().block();
+
+    provider.setRolloutPercentage("gate-a", 80).block();
+
+    assertEquals(50, snapshot.get("gate-a"), "snapshot must not reflect subsequent mutations");
+  }
+
+  @Test
+  void concurrentSetRolloutPercentage_doesNotCorruptState() {
+    var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of());
+    int threadCount = 100;
+    List<String> gates = new ArrayList<>();
+    for (int i = 0; i < threadCount; i++) {
+      gates.add("gate-" + i);
+    }
+
+    try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      for (String gate : gates) {
+        executor.submit(() -> provider.setRolloutPercentage(gate, 50).block());
+      }
+    }
+
+    assertEquals(threadCount, provider.getRolloutPercentages().block().size());
+    gates.forEach(gate -> assertEquals(50, provider.getRolloutPercentage(gate).block()));
+  }
+
+  @Test
+  void removeRolloutPercentage_removesExistingEntry() {
+    var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of("gate-a", 50));
+
+    Boolean removed = provider.removeRolloutPercentage("gate-a").block();
+
+    assertTrue(removed);
+    assertNull(provider.getRolloutPercentage("gate-a").block());
+    assertTrue(provider.getRolloutPercentages().block().isEmpty());
+  }
+
+  @Test
+  void removeRolloutPercentage_isNoOp_whenEntryDoesNotExist() {
+    var provider = new MutableInMemoryReactiveRolloutPercentageProvider(Map.of("gate-a", 50));
+
+    Boolean removed = provider.removeRolloutPercentage("nonexistent").block();
+
+    assertFalse(removed);
+    assertEquals(50, provider.getRolloutPercentage("gate-a").block());
+    assertEquals(Map.of("gate-a", 50), provider.getRolloutPercentages().block());
+  }
+}


### PR DESCRIPTION
## Summary

- Issue #8 (Phase 3) の実装: `feature-flag-spring-boot-starter` の `core` モジュールから Reactor 依存の23クラスを `reactive-core` モジュールへ移植・リネーム
- パッケージ: `net.brightroom.endpointgate.reactive.core`
- `./gradlew :reactive-core:check` が成功することを確認済み

## 主な変更

| 旧クラス名 | 新クラス名 |
|-----------|-----------|
| `ReactiveFeatureFlagProvider` | `ReactiveEndpointGateProvider` |
| `MutableReactiveFeatureFlagProvider` | `MutableReactiveEndpointGateProvider` |
| `ReactiveFeatureFlagConditionEvaluator` | `ReactiveEndpointGateConditionEvaluator` |
| `ReactiveFeatureFlagEvaluationPipeline` | `ReactiveEndpointGateEvaluationPipeline` |
| `MutableInMemoryReactiveFeatureFlagProvider` | `MutableInMemoryReactiveEndpointGateProvider` |

その他の変更:
- `featureName` → `gateId` に統一
- `FeatureFlagContext` → `EndpointGateContext`
- `ReactiveEvaluationStep` から `@Order` を除去
- `ReactiveEndpointGateEvaluationPipeline` でステップ順序をハードコード (Enabled → Schedule → Condition → Rollout)
- `InMemoryReactiveEndpointGateProvider` (新規: 不変版) を追加

## Test plan

- [x] `./gradlew :reactive-core:check` が成功する
- [x] Provider SPI・InMemory 実装のユニットテスト (MutableInMemoryReactiveEndpointGateProvider, MutableInMemoryReactiveRolloutPercentageProvider, InMemoryReactiveScheduleProvider)
- [x] Reactive EvaluationPipeline のユニットテスト (全4ステップ)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)