### PR TITLE
Close #11: implement spring-webflux module

### DIFF
--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateAspectConditionIntegrationTest.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateAspectConditionIntegrationTest.java
@@ -1,0 +1,116 @@
+package net.brightroom.endpointgate.spring.webflux;
+
+import net.brightroom.endpointgate.spring.webflux.configuration.EndpointGateWebFluxTestAutoConfiguration;
+import net.brightroom.endpointgate.spring.webflux.endpoint.EndpointGateConditionController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@WebFluxTest(controllers = EndpointGateConditionController.class)
+@Import(EndpointGateWebFluxTestAutoConfiguration.class)
+@TestPropertySource(
+    properties = {
+      "endpoint-gate.gates.header-condition-feature.enabled=true",
+      "endpoint-gate.gates.header-condition-feature.condition=headers['X-Beta'] != null",
+      "endpoint-gate.gates.param-condition-feature.enabled=true",
+      "endpoint-gate.gates.param-condition-feature.condition=params['variant'] == 'B'",
+      "endpoint-gate.gates.condition-rollout-feature.enabled=true",
+      "endpoint-gate.gates.condition-rollout-feature.condition=headers['X-Beta'] != null",
+      "endpoint-gate.gates.condition-rollout-feature.rollout=100",
+      "endpoint-gate.gates.remote-address-condition-feature.enabled=true",
+      "endpoint-gate.gates.remote-address-condition-feature.condition=remoteAddress == '127.0.0.1'",
+    })
+class EndpointGateAspectConditionIntegrationTest {
+
+  WebTestClient webTestClient;
+
+  @Test
+  void shouldAllowAccess_whenHeaderConditionIsSatisfied() {
+    webTestClient
+        .get()
+        .uri("/condition/header")
+        .header("X-Beta", "true")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Test
+  void shouldBlockAccess_whenHeaderConditionIsNotSatisfied() {
+    webTestClient
+        .get()
+        .uri("/condition/header")
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectBody()
+        .json(
+            """
+            {
+              "detail" : "Gate 'header-condition-feature' is not available",
+              "instance" : "/condition/header",
+              "status" : 403,
+              "title" : "Endpoint gate access denied",
+              "type" : "https://github.com/bright-room/endpoint-gate#response-types"
+            }
+            """);
+  }
+
+  @Test
+  void shouldAllowAccess_whenParamConditionIsSatisfied() {
+    webTestClient
+        .get()
+        .uri("/condition/param?variant=B")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Test
+  void shouldBlockAccess_whenParamConditionIsNotSatisfied() {
+    webTestClient.get().uri("/condition/param?variant=A").exchange().expectStatus().isForbidden();
+  }
+
+  @Test
+  void shouldBlockAccess_whenParamIsMissing() {
+    webTestClient.get().uri("/condition/param").exchange().expectStatus().isForbidden();
+  }
+
+  @Test
+  void shouldBlockAccess_onConditionWithRollout_whenConditionIsNotSatisfied() {
+    // condition fails (no X-Beta header) — access denied regardless of rollout
+    webTestClient.get().uri("/condition/with-rollout").exchange().expectStatus().isForbidden();
+  }
+
+  @Test
+  void shouldAllowAccess_onConditionWithRollout_whenConditionSatisfiedAndRolloutFull() {
+    // rollout overridden to 100% via property, condition satisfied
+    webTestClient
+        .get()
+        .uri("/condition/with-rollout")
+        .header("X-Beta", "true")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Test
+  void shouldBlockAccess_whenRemoteAddressConditionIsNotSatisfied() {
+    // @WebFluxTest slice does not set a real remote address, so the condition fails
+    webTestClient.get().uri("/condition/remote-address").exchange().expectStatus().isForbidden();
+  }
+
+  @Autowired
+  EndpointGateAspectConditionIntegrationTest(WebTestClient webTestClient) {
+    this.webTestClient = webTestClient;
+  }
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateAspectFailClosedIntegrationTest.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateAspectFailClosedIntegrationTest.java
@@ -1,0 +1,49 @@
+package net.brightroom.endpointgate.spring.webflux;
+
+import net.brightroom.endpointgate.spring.webflux.configuration.EndpointGateWebFluxTestAutoConfiguration;
+import net.brightroom.endpointgate.spring.webflux.endpoint.EndpointGateUndefinedGateController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * Verifies fail-closed behavior: when {@code endpoint-gate.default-enabled} is {@code false},
+ * requests to endpoints whose gate is absent from {@code endpoint-gate.gates} in {@code
+ * application.yaml} are blocked with {@code 403 Forbidden}.
+ */
+@WebFluxTest(
+    properties = {"endpoint-gate.default-enabled=false"},
+    controllers = EndpointGateUndefinedGateController.class)
+@Import(EndpointGateWebFluxTestAutoConfiguration.class)
+class EndpointGateAspectFailClosedIntegrationTest {
+
+  WebTestClient webTestClient;
+
+  @Test
+  void shouldBlockAccess_whenGateIsUndefinedInConfig_andDefaultEnabledIsFalse() {
+    webTestClient
+        .get()
+        .uri("/undefined-flag-endpoint")
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectBody()
+        .json(
+            """
+            {
+              "detail"   : "Gate 'undefined-in-config-flag' is not available",
+              "instance" : "/undefined-flag-endpoint",
+              "status"   : 403,
+              "title"    : "Endpoint gate access denied",
+              "type"     : "https://github.com/bright-room/endpoint-gate#response-types"
+            }
+            """);
+  }
+
+  @Autowired
+  EndpointGateAspectFailClosedIntegrationTest(WebTestClient webTestClient) {
+    this.webTestClient = webTestClient;
+  }
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateAspectFailOpenIntegrationTest.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateAspectFailOpenIntegrationTest.java
@@ -1,0 +1,40 @@
+package net.brightroom.endpointgate.spring.webflux;
+
+import net.brightroom.endpointgate.spring.webflux.configuration.EndpointGateWebFluxTestAutoConfiguration;
+import net.brightroom.endpointgate.spring.webflux.endpoint.EndpointGateUndefinedGateController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * Verifies fail-open behavior: when {@code endpoint-gate.default-enabled} is {@code true}, requests
+ * to endpoints whose gate is absent from {@code endpoint-gate.gates} in {@code application.yaml}
+ * are allowed through.
+ */
+@WebFluxTest(
+    properties = {"endpoint-gate.default-enabled=true"},
+    controllers = EndpointGateUndefinedGateController.class)
+@Import(EndpointGateWebFluxTestAutoConfiguration.class)
+class EndpointGateAspectFailOpenIntegrationTest {
+
+  WebTestClient webTestClient;
+
+  @Test
+  void shouldAllowAccess_whenGateIsUndefinedInConfig_andDefaultEnabledIsTrue() {
+    webTestClient
+        .get()
+        .uri("/undefined-flag-endpoint")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Autowired
+  EndpointGateAspectFailOpenIntegrationTest(WebTestClient webTestClient) {
+    this.webTestClient = webTestClient;
+  }
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateAspectHtmlResponseIntegrationTest.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateAspectHtmlResponseIntegrationTest.java
@@ -1,0 +1,133 @@
+package net.brightroom.endpointgate.spring.webflux;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import net.brightroom.endpointgate.spring.webflux.configuration.EndpointGateWebFluxTestAutoConfiguration;
+import net.brightroom.endpointgate.spring.webflux.endpoint.EndpointGateDisableController;
+import net.brightroom.endpointgate.spring.webflux.endpoint.EndpointGateEnableController;
+import net.brightroom.endpointgate.spring.webflux.endpoint.EndpointGateMethodLevelController;
+import net.brightroom.endpointgate.spring.webflux.endpoint.NoEndpointGateController;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@WebFluxTest(
+    properties = {"endpoint-gate.response.type=HTML"},
+    controllers = {
+      NoEndpointGateController.class,
+      EndpointGateEnableController.class,
+      EndpointGateDisableController.class,
+      EndpointGateMethodLevelController.class,
+    })
+@Import(EndpointGateWebFluxTestAutoConfiguration.class)
+class EndpointGateAspectHtmlResponseIntegrationTest {
+
+  WebTestClient webTestClient;
+
+  @Test
+  void shouldAllowAccess_whenNoAnnotated() {
+    webTestClient
+        .get()
+        .uri("/stable-endpoint")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("No Annotation");
+  }
+
+  @Test
+  void shouldAllowAccess_whenGateIsEnabled() {
+    webTestClient
+        .get()
+        .uri("/experimental-stage-endpoint")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Test
+  void shouldBlockAccess_whenGateIsDisabled() {
+    String html =
+        webTestClient
+            .get()
+            .uri("/development-stage-endpoint")
+            .exchange()
+            .expectStatus()
+            .isForbidden()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+    Document doc = Jsoup.parse(html);
+    assertEquals("Access Denied", doc.title());
+    assertEquals("403 - Access Denied", doc.select("h1").text());
+    assertEquals("Gate 'development-stage-endpoint' is not available", doc.select("p").text());
+  }
+
+  @Test
+  void shouldAllowAccess_whenNoEndpointGateAnnotationOnController() {
+    webTestClient
+        .get()
+        .uri("/test/no-annotation")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("No Annotation");
+  }
+
+  @Test
+  void shouldBlockAccess_whenClassLevelGateIsDisabled() {
+    String html =
+        webTestClient
+            .get()
+            .uri("/test/disable")
+            .exchange()
+            .expectStatus()
+            .isForbidden()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+    Document doc = Jsoup.parse(html);
+    assertEquals("Access Denied", doc.title());
+    assertEquals("403 - Access Denied", doc.select("h1").text());
+    assertEquals("Gate 'disable-class-level-feature' is not available", doc.select("p").text());
+  }
+
+  @Test
+  void shouldAllowAccess_whenClassLevelGateIsEnabled() {
+    webTestClient
+        .get()
+        .uri("/test/enabled")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Test
+  void shouldAllowAccess_whenMethodAnnotationOverridesClassAnnotation() {
+    webTestClient
+        .get()
+        .uri("/test/method-override")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Method Override Allowed");
+  }
+
+  @Autowired
+  EndpointGateAspectHtmlResponseIntegrationTest(WebTestClient webTestClient) {
+    this.webTestClient = webTestClient;
+  }
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateAspectJsonResponseIntegrationTest.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateAspectJsonResponseIntegrationTest.java
@@ -1,0 +1,132 @@
+package net.brightroom.endpointgate.spring.webflux;
+
+import net.brightroom.endpointgate.spring.webflux.configuration.EndpointGateWebFluxTestAutoConfiguration;
+import net.brightroom.endpointgate.spring.webflux.endpoint.EndpointGateDisableController;
+import net.brightroom.endpointgate.spring.webflux.endpoint.EndpointGateEnableController;
+import net.brightroom.endpointgate.spring.webflux.endpoint.EndpointGateMethodLevelController;
+import net.brightroom.endpointgate.spring.webflux.endpoint.NoEndpointGateController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@WebFluxTest(
+    controllers = {
+      NoEndpointGateController.class,
+      EndpointGateEnableController.class,
+      EndpointGateDisableController.class,
+      EndpointGateMethodLevelController.class,
+    })
+@Import(EndpointGateWebFluxTestAutoConfiguration.class)
+class EndpointGateAspectJsonResponseIntegrationTest {
+
+  WebTestClient webTestClient;
+
+  @Test
+  void shouldAllowAccess_whenNoAnnotated() {
+    webTestClient
+        .get()
+        .uri("/stable-endpoint")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("No Annotation");
+  }
+
+  @Test
+  void shouldAllowAccess_whenGateIsEnabled() {
+    webTestClient
+        .get()
+        .uri("/experimental-stage-endpoint")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Test
+  void shouldBlockAccess_whenGateIsDisabled() {
+    webTestClient
+        .get()
+        .uri("/development-stage-endpoint")
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectBody()
+        .json(
+            """
+            {
+              "detail" : "Gate 'development-stage-endpoint' is not available",
+              "instance" : "/development-stage-endpoint",
+              "status" : 403,
+              "title" : "Endpoint gate access denied",
+              "type" : "https://github.com/bright-room/endpoint-gate#response-types"
+            }
+            """);
+  }
+
+  @Test
+  void shouldAllowAccess_whenNoEndpointGateAnnotationOnController() {
+    webTestClient
+        .get()
+        .uri("/test/no-annotation")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("No Annotation");
+  }
+
+  @Test
+  void shouldBlockAccess_whenClassLevelGateIsDisabled() {
+    webTestClient
+        .get()
+        .uri("/test/disable")
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectBody()
+        .json(
+            """
+            {
+              "detail" : "Gate 'disable-class-level-feature' is not available",
+              "instance" : "/test/disable",
+              "status" : 403,
+              "title" : "Endpoint gate access denied",
+              "type" : "https://github.com/bright-room/endpoint-gate#response-types"
+            }
+            """);
+  }
+
+  @Test
+  void shouldAllowAccess_whenClassLevelGateIsEnabled() {
+    webTestClient
+        .get()
+        .uri("/test/enabled")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Test
+  void shouldAllowAccess_whenMethodAnnotationOverridesClassAnnotation() {
+    webTestClient
+        .get()
+        .uri("/test/method-override")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Method Override Allowed");
+  }
+
+  @Autowired
+  EndpointGateAspectJsonResponseIntegrationTest(WebTestClient webTestClient) {
+    this.webTestClient = webTestClient;
+  }
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateAspectPlainTextResponseIntegrationTest.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateAspectPlainTextResponseIntegrationTest.java
@@ -1,0 +1,115 @@
+package net.brightroom.endpointgate.spring.webflux;
+
+import net.brightroom.endpointgate.spring.webflux.configuration.EndpointGateWebFluxTestAutoConfiguration;
+import net.brightroom.endpointgate.spring.webflux.endpoint.EndpointGateDisableController;
+import net.brightroom.endpointgate.spring.webflux.endpoint.EndpointGateEnableController;
+import net.brightroom.endpointgate.spring.webflux.endpoint.EndpointGateMethodLevelController;
+import net.brightroom.endpointgate.spring.webflux.endpoint.NoEndpointGateController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@WebFluxTest(
+    properties = {"endpoint-gate.response.type=PLAIN_TEXT"},
+    controllers = {
+      NoEndpointGateController.class,
+      EndpointGateEnableController.class,
+      EndpointGateDisableController.class,
+      EndpointGateMethodLevelController.class,
+    })
+@Import(EndpointGateWebFluxTestAutoConfiguration.class)
+class EndpointGateAspectPlainTextResponseIntegrationTest {
+
+  WebTestClient webTestClient;
+
+  @Test
+  void shouldAllowAccess_whenNoAnnotated() {
+    webTestClient
+        .get()
+        .uri("/stable-endpoint")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("No Annotation");
+  }
+
+  @Test
+  void shouldAllowAccess_whenGateIsEnabled() {
+    webTestClient
+        .get()
+        .uri("/experimental-stage-endpoint")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Test
+  void shouldBlockAccess_whenGateIsDisabled() {
+    webTestClient
+        .get()
+        .uri("/development-stage-endpoint")
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectBody(String.class)
+        .isEqualTo("Gate 'development-stage-endpoint' is not available");
+  }
+
+  @Test
+  void shouldAllowAccess_whenNoEndpointGateAnnotationOnController() {
+    webTestClient
+        .get()
+        .uri("/test/no-annotation")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("No Annotation");
+  }
+
+  @Test
+  void shouldBlockAccess_whenClassLevelGateIsDisabled() {
+    webTestClient
+        .get()
+        .uri("/test/disable")
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectBody(String.class)
+        .isEqualTo("Gate 'disable-class-level-feature' is not available");
+  }
+
+  @Test
+  void shouldAllowAccess_whenClassLevelGateIsEnabled() {
+    webTestClient
+        .get()
+        .uri("/test/enabled")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Test
+  void shouldAllowAccess_whenMethodAnnotationOverridesClassAnnotation() {
+    webTestClient
+        .get()
+        .uri("/test/method-override")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Method Override Allowed");
+  }
+
+  @Autowired
+  EndpointGateAspectPlainTextResponseIntegrationTest(WebTestClient webTestClient) {
+    this.webTestClient = webTestClient;
+  }
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateAspectRolloutIntegrationTest.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateAspectRolloutIntegrationTest.java
@@ -1,0 +1,90 @@
+package net.brightroom.endpointgate.spring.webflux;
+
+import net.brightroom.endpointgate.core.context.EndpointGateContext;
+import net.brightroom.endpointgate.core.rollout.DefaultRolloutStrategy;
+import net.brightroom.endpointgate.spring.webflux.context.ReactiveEndpointGateContextResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+
+/**
+ * Verifies rollout behavior through the full WebFlux stack with a real Netty server:
+ *
+ * <ul>
+ *   <li>Custom {@link ReactiveEndpointGateContextResolver} bean is respected via
+ *       {@code @ConditionalOnMissingBean}, enabling sticky rollout.
+ *   <li>Rollout decision is deterministic for a fixed user identifier.
+ *   <li>Class-level {@code @EndpointGate} with {@code rollout} is processed correctly by the
+ *       aspect.
+ * </ul>
+ *
+ * <p>A real Netty server is used (instead of {@code @WebFluxTest}) to ensure the full Spring
+ * WebFlux pipeline — including {@code DispatcherHandler}'s Reactor context propagation of {@code
+ * ServerWebExchange} — is exercised.
+ */
+@SpringBootTest(
+    webEnvironment = WebEnvironment.RANDOM_PORT,
+    properties = {
+      "endpoint-gate.gates.rollout-feature.enabled=true",
+      "endpoint-gate.gates.rollout-feature.rollout=50"
+    })
+class EndpointGateAspectRolloutIntegrationTest {
+
+  private static final EndpointGateContext FIXED_CONTEXT = new EndpointGateContext("fixed-user-id");
+  private static final boolean IN_ROLLOUT_50 =
+      new DefaultRolloutStrategy().isInRollout("rollout-feature", FIXED_CONTEXT, 50);
+
+  @TestConfiguration
+  static class FixedContextResolverConfig {
+    @Bean
+    ReactiveEndpointGateContextResolver contextResolver() {
+      return request -> Mono.just(FIXED_CONTEXT);
+    }
+  }
+
+  @LocalServerPort int port;
+
+  WebTestClient webTestClient;
+
+  @BeforeEach
+  void setUp() {
+    webTestClient = WebTestClient.bindToServer().baseUrl("http://localhost:" + port).build();
+  }
+
+  @Test
+  void methodLevel_stickyRollout_returnsDeterministicResult_forFixedUserId() {
+    if (IN_ROLLOUT_50) {
+      webTestClient.get().uri("/test/rollout").exchange().expectStatus().isOk();
+    } else {
+      webTestClient.get().uri("/test/rollout").exchange().expectStatus().isForbidden();
+    }
+  }
+
+  @Test
+  void methodLevel_stickyRollout_sameUserAlwaysGetsSameResult() {
+    // Call twice — result must be identical (deterministic hashing)
+    for (int i = 0; i < 2; i++) {
+      if (IN_ROLLOUT_50) {
+        webTestClient.get().uri("/test/rollout").exchange().expectStatus().isOk();
+      } else {
+        webTestClient.get().uri("/test/rollout").exchange().expectStatus().isForbidden();
+      }
+    }
+  }
+
+  @Test
+  void classLevel_stickyRollout_returnsDeterministicResult_forFixedUserId() {
+    // Verifies that class-level @EndpointGate with rollout is processed through the aspect
+    if (IN_ROLLOUT_50) {
+      webTestClient.get().uri("/test/class-rollout").exchange().expectStatus().isOk();
+    } else {
+      webTestClient.get().uri("/test/class-rollout").exchange().expectStatus().isForbidden();
+    }
+  }
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateCustomExceptionHandlerIntegrationTest.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateCustomExceptionHandlerIntegrationTest.java
@@ -1,0 +1,66 @@
+package net.brightroom.endpointgate.spring.webflux;
+
+import net.brightroom.endpointgate.core.exception.EndpointGateAccessDeniedException;
+import net.brightroom.endpointgate.spring.webflux.configuration.EndpointGateWebFluxTestAutoConfiguration;
+import net.brightroom.endpointgate.spring.webflux.endpoint.EndpointGateDisableController;
+import net.brightroom.endpointgate.spring.webflux.endpoint.EndpointGateMethodLevelController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@WebFluxTest(
+    controllers = {EndpointGateDisableController.class, EndpointGateMethodLevelController.class})
+@Import({
+  EndpointGateWebFluxTestAutoConfiguration.class,
+  EndpointGateCustomExceptionHandlerIntegrationTest.CustomExceptionHandler.class
+})
+class EndpointGateCustomExceptionHandlerIntegrationTest {
+
+  @ControllerAdvice
+  @Order(0)
+  static class CustomExceptionHandler {
+
+    @ExceptionHandler(EndpointGateAccessDeniedException.class)
+    ResponseEntity<String> handle(EndpointGateAccessDeniedException e) {
+      return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body("custom: " + e.gateId());
+    }
+  }
+
+  WebTestClient webTestClient;
+
+  @Test
+  void customResolutionTakesPriority_whenClassLevelGateIsDisabled() {
+    webTestClient
+        .get()
+        .uri("/test/disable")
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE)
+        .expectBody(String.class)
+        .isEqualTo("custom: disable-class-level-feature");
+  }
+
+  @Test
+  void customResolutionTakesPriority_whenMethodLevelGateIsDisabled() {
+    webTestClient
+        .get()
+        .uri("/development-stage-endpoint")
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE)
+        .expectBody(String.class)
+        .isEqualTo("custom: development-stage-endpoint");
+  }
+
+  @Autowired
+  EndpointGateCustomExceptionHandlerIntegrationTest(WebTestClient webTestClient) {
+    this.webTestClient = webTestClient;
+  }
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateHandlerFilterFunctionConditionIntegrationTest.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateHandlerFilterFunctionConditionIntegrationTest.java
@@ -1,0 +1,82 @@
+package net.brightroom.endpointgate.spring.webflux;
+
+import net.brightroom.endpointgate.spring.webflux.configuration.EndpointGateWebFluxTestAutoConfiguration;
+import net.brightroom.endpointgate.spring.webflux.endpoint.EndpointGateRouterConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@WebFluxTest
+@Import({EndpointGateWebFluxTestAutoConfiguration.class, EndpointGateRouterConfiguration.class})
+@TestPropertySource(
+    properties = {
+      "endpoint-gate.gates.conditional-feature.enabled=true",
+    })
+class EndpointGateHandlerFilterFunctionConditionIntegrationTest {
+
+  WebTestClient webTestClient;
+
+  @Test
+  void shouldAllowAccess_whenHeaderConditionIsSatisfied() {
+    webTestClient
+        .get()
+        .uri("/functional/condition/header")
+        .header("X-Beta", "true")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Test
+  void shouldBlockAccess_whenHeaderConditionIsNotSatisfied() {
+    webTestClient
+        .get()
+        .uri("/functional/condition/header")
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectBody()
+        .json(
+            """
+            {
+              "detail" : "Gate 'conditional-feature' is not available",
+              "instance" : "/functional/condition/header",
+              "status" : 403,
+              "title" : "Endpoint gate access denied",
+              "type" : "https://github.com/bright-room/endpoint-gate#response-types"
+            }
+            """);
+  }
+
+  @Test
+  void shouldAllowAccess_whenParamConditionIsSatisfied() {
+    webTestClient
+        .get()
+        .uri("/functional/condition/param?variant=B")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Test
+  void shouldBlockAccess_whenParamConditionIsNotSatisfied() {
+    webTestClient
+        .get()
+        .uri("/functional/condition/param?variant=A")
+        .exchange()
+        .expectStatus()
+        .isForbidden();
+  }
+
+  @Autowired
+  EndpointGateHandlerFilterFunctionConditionIntegrationTest(WebTestClient webTestClient) {
+    this.webTestClient = webTestClient;
+  }
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateHandlerFilterFunctionCustomResolutionIntegrationTest.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateHandlerFilterFunctionCustomResolutionIntegrationTest.java
@@ -1,0 +1,67 @@
+package net.brightroom.endpointgate.spring.webflux;
+
+import net.brightroom.endpointgate.spring.webflux.configuration.EndpointGateWebFluxTestAutoConfiguration;
+import net.brightroom.endpointgate.spring.webflux.endpoint.EndpointGateRouterConfiguration;
+import net.brightroom.endpointgate.spring.webflux.resolution.handlerfilter.AccessDeniedHandlerFilterResolution;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+@WebFluxTest
+@Import({
+  EndpointGateHandlerFilterFunctionCustomResolutionIntegrationTest.CustomResolutionConfiguration
+      .class,
+  EndpointGateWebFluxTestAutoConfiguration.class,
+  EndpointGateRouterConfiguration.class,
+})
+class EndpointGateHandlerFilterFunctionCustomResolutionIntegrationTest {
+
+  @Configuration
+  static class CustomResolutionConfiguration {
+
+    @Bean
+    @Primary
+    AccessDeniedHandlerFilterResolution customResolution() {
+      return (request, e) ->
+          ServerResponse.status(HttpStatus.SERVICE_UNAVAILABLE).bodyValue("custom: " + e.gateId());
+    }
+  }
+
+  WebTestClient webTestClient;
+
+  @Test
+  void customResolutionTakesPriority_whenGateIsDisabled() {
+    webTestClient
+        .get()
+        .uri("/functional/development-stage-endpoint")
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE)
+        .expectBody(String.class)
+        .isEqualTo("custom: development-stage-endpoint");
+  }
+
+  @Test
+  void customResolutionTakesPriority_whenClassLevelGateIsDisabled() {
+    webTestClient
+        .get()
+        .uri("/functional/test/disable")
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE)
+        .expectBody(String.class)
+        .isEqualTo("custom: disable-class-level-feature");
+  }
+
+  @Autowired
+  EndpointGateHandlerFilterFunctionCustomResolutionIntegrationTest(WebTestClient webTestClient) {
+    this.webTestClient = webTestClient;
+  }
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateHandlerFilterFunctionFailClosedIntegrationTest.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateHandlerFilterFunctionFailClosedIntegrationTest.java
@@ -1,0 +1,47 @@
+package net.brightroom.endpointgate.spring.webflux;
+
+import net.brightroom.endpointgate.spring.webflux.configuration.EndpointGateWebFluxTestAutoConfiguration;
+import net.brightroom.endpointgate.spring.webflux.endpoint.EndpointGateRouterConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * Verifies fail-closed behavior for Functional Endpoints: when {@code
+ * endpoint-gate.default-enabled} is {@code false}, requests to routes whose gate is absent from
+ * {@code endpoint-gate.gates} in {@code application.yaml} are blocked with {@code 403 Forbidden}.
+ */
+@WebFluxTest(properties = {"endpoint-gate.default-enabled=false"})
+@Import({EndpointGateWebFluxTestAutoConfiguration.class, EndpointGateRouterConfiguration.class})
+class EndpointGateHandlerFilterFunctionFailClosedIntegrationTest {
+
+  WebTestClient webTestClient;
+
+  @Test
+  void shouldBlockAccess_whenGateIsUndefinedInConfig_andDefaultEnabledIsFalse() {
+    webTestClient
+        .get()
+        .uri("/functional/undefined-flag-endpoint")
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectBody()
+        .json(
+            """
+            {
+              "detail"   : "Gate 'undefined-in-config-flag' is not available",
+              "instance" : "/functional/undefined-flag-endpoint",
+              "status"   : 403,
+              "title"    : "Endpoint gate access denied",
+              "type"     : "https://github.com/bright-room/endpoint-gate#response-types"
+            }
+            """);
+  }
+
+  @Autowired
+  EndpointGateHandlerFilterFunctionFailClosedIntegrationTest(WebTestClient webTestClient) {
+    this.webTestClient = webTestClient;
+  }
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateHandlerFilterFunctionFailOpenIntegrationTest.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateHandlerFilterFunctionFailOpenIntegrationTest.java
@@ -1,0 +1,38 @@
+package net.brightroom.endpointgate.spring.webflux;
+
+import net.brightroom.endpointgate.spring.webflux.configuration.EndpointGateWebFluxTestAutoConfiguration;
+import net.brightroom.endpointgate.spring.webflux.endpoint.EndpointGateRouterConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * Verifies fail-open behavior for Functional Endpoints: when {@code endpoint-gate.default-enabled}
+ * is {@code true}, requests to routes whose gate is absent from {@code endpoint-gate.gates} in
+ * {@code application.yaml} are allowed through.
+ */
+@WebFluxTest(properties = {"endpoint-gate.default-enabled=true"})
+@Import({EndpointGateWebFluxTestAutoConfiguration.class, EndpointGateRouterConfiguration.class})
+class EndpointGateHandlerFilterFunctionFailOpenIntegrationTest {
+
+  WebTestClient webTestClient;
+
+  @Test
+  void shouldAllowAccess_whenGateIsUndefinedInConfig_andDefaultEnabledIsTrue() {
+    webTestClient
+        .get()
+        .uri("/functional/undefined-flag-endpoint")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Autowired
+  EndpointGateHandlerFilterFunctionFailOpenIntegrationTest(WebTestClient webTestClient) {
+    this.webTestClient = webTestClient;
+  }
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateHandlerFilterFunctionHtmlResponseIntegrationTest.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateHandlerFilterFunctionHtmlResponseIntegrationTest.java
@@ -1,0 +1,99 @@
+package net.brightroom.endpointgate.spring.webflux;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import net.brightroom.endpointgate.spring.webflux.configuration.EndpointGateWebFluxTestAutoConfiguration;
+import net.brightroom.endpointgate.spring.webflux.endpoint.EndpointGateRouterConfiguration;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@WebFluxTest(properties = {"endpoint-gate.response.type=HTML"})
+@Import({EndpointGateWebFluxTestAutoConfiguration.class, EndpointGateRouterConfiguration.class})
+class EndpointGateHandlerFilterFunctionHtmlResponseIntegrationTest {
+
+  WebTestClient webTestClient;
+
+  @Test
+  void shouldAllowAccess_whenNoFilter() {
+    webTestClient
+        .get()
+        .uri("/functional/stable-endpoint")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("No Annotation");
+  }
+
+  @Test
+  void shouldAllowAccess_whenGateIsEnabled() {
+    webTestClient
+        .get()
+        .uri("/functional/experimental-stage-endpoint")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Test
+  void shouldBlockAccess_whenGateIsDisabled() {
+    String html =
+        webTestClient
+            .get()
+            .uri("/functional/development-stage-endpoint")
+            .exchange()
+            .expectStatus()
+            .isForbidden()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+    Document doc = Jsoup.parse(html);
+    assertEquals("Access Denied", doc.title());
+    assertEquals("403 - Access Denied", doc.select("h1").text());
+    assertEquals("Gate 'development-stage-endpoint' is not available", doc.select("p").text());
+  }
+
+  @Test
+  void shouldBlockAccess_whenClassLevelGateIsDisabled() {
+    String html =
+        webTestClient
+            .get()
+            .uri("/functional/test/disable")
+            .exchange()
+            .expectStatus()
+            .isForbidden()
+            .expectBody(String.class)
+            .returnResult()
+            .getResponseBody();
+
+    Document doc = Jsoup.parse(html);
+    assertEquals("Access Denied", doc.title());
+    assertEquals("403 - Access Denied", doc.select("h1").text());
+    assertEquals("Gate 'disable-class-level-feature' is not available", doc.select("p").text());
+  }
+
+  @Test
+  void shouldAllowAccess_whenClassLevelGateIsEnabled() {
+    webTestClient
+        .get()
+        .uri("/functional/test/enabled")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Autowired
+  EndpointGateHandlerFilterFunctionHtmlResponseIntegrationTest(WebTestClient webTestClient) {
+    this.webTestClient = webTestClient;
+  }
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateHandlerFilterFunctionJsonResponseIntegrationTest.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateHandlerFilterFunctionJsonResponseIntegrationTest.java
@@ -1,0 +1,99 @@
+package net.brightroom.endpointgate.spring.webflux;
+
+import net.brightroom.endpointgate.spring.webflux.configuration.EndpointGateWebFluxTestAutoConfiguration;
+import net.brightroom.endpointgate.spring.webflux.endpoint.EndpointGateRouterConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@WebFluxTest
+@Import({EndpointGateWebFluxTestAutoConfiguration.class, EndpointGateRouterConfiguration.class})
+class EndpointGateHandlerFilterFunctionJsonResponseIntegrationTest {
+
+  WebTestClient webTestClient;
+
+  @Test
+  void shouldAllowAccess_whenNoFilter() {
+    webTestClient
+        .get()
+        .uri("/functional/stable-endpoint")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("No Annotation");
+  }
+
+  @Test
+  void shouldAllowAccess_whenGateIsEnabled() {
+    webTestClient
+        .get()
+        .uri("/functional/experimental-stage-endpoint")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Test
+  void shouldBlockAccess_whenGateIsDisabled() {
+    webTestClient
+        .get()
+        .uri("/functional/development-stage-endpoint")
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectBody()
+        .json(
+            """
+            {
+              "detail" : "Gate 'development-stage-endpoint' is not available",
+              "instance" : "/functional/development-stage-endpoint",
+              "status" : 403,
+              "title" : "Endpoint gate access denied",
+              "type" : "https://github.com/bright-room/endpoint-gate#response-types"
+            }
+            """);
+  }
+
+  @Test
+  void shouldBlockAccess_whenClassLevelGateIsDisabled() {
+    webTestClient
+        .get()
+        .uri("/functional/test/disable")
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectBody()
+        .json(
+            """
+            {
+              "detail" : "Gate 'disable-class-level-feature' is not available",
+              "instance" : "/functional/test/disable",
+              "status" : 403,
+              "title" : "Endpoint gate access denied",
+              "type" : "https://github.com/bright-room/endpoint-gate#response-types"
+            }
+            """);
+  }
+
+  @Test
+  void shouldAllowAccess_whenClassLevelGateIsEnabled() {
+    webTestClient
+        .get()
+        .uri("/functional/test/enabled")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Autowired
+  EndpointGateHandlerFilterFunctionJsonResponseIntegrationTest(WebTestClient webTestClient) {
+    this.webTestClient = webTestClient;
+  }
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateHandlerFilterFunctionPlainTextResponseIntegrationTest.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateHandlerFilterFunctionPlainTextResponseIntegrationTest.java
@@ -1,0 +1,81 @@
+package net.brightroom.endpointgate.spring.webflux;
+
+import net.brightroom.endpointgate.spring.webflux.configuration.EndpointGateWebFluxTestAutoConfiguration;
+import net.brightroom.endpointgate.spring.webflux.endpoint.EndpointGateRouterConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@WebFluxTest(properties = {"endpoint-gate.response.type=PLAIN_TEXT"})
+@Import({EndpointGateWebFluxTestAutoConfiguration.class, EndpointGateRouterConfiguration.class})
+class EndpointGateHandlerFilterFunctionPlainTextResponseIntegrationTest {
+
+  WebTestClient webTestClient;
+
+  @Test
+  void shouldAllowAccess_whenNoFilter() {
+    webTestClient
+        .get()
+        .uri("/functional/stable-endpoint")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("No Annotation");
+  }
+
+  @Test
+  void shouldAllowAccess_whenGateIsEnabled() {
+    webTestClient
+        .get()
+        .uri("/functional/experimental-stage-endpoint")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Test
+  void shouldBlockAccess_whenGateIsDisabled() {
+    webTestClient
+        .get()
+        .uri("/functional/development-stage-endpoint")
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectBody(String.class)
+        .isEqualTo("Gate 'development-stage-endpoint' is not available");
+  }
+
+  @Test
+  void shouldBlockAccess_whenClassLevelGateIsDisabled() {
+    webTestClient
+        .get()
+        .uri("/functional/test/disable")
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectBody(String.class)
+        .isEqualTo("Gate 'disable-class-level-feature' is not available");
+  }
+
+  @Test
+  void shouldAllowAccess_whenClassLevelGateIsEnabled() {
+    webTestClient
+        .get()
+        .uri("/functional/test/enabled")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Autowired
+  EndpointGateHandlerFilterFunctionPlainTextResponseIntegrationTest(WebTestClient webTestClient) {
+    this.webTestClient = webTestClient;
+  }
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateHandlerFilterFunctionRolloutIntegrationTest.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateHandlerFilterFunctionRolloutIntegrationTest.java
@@ -1,0 +1,108 @@
+package net.brightroom.endpointgate.spring.webflux;
+
+import static org.springframework.web.reactive.function.server.RouterFunctions.route;
+
+import net.brightroom.endpointgate.core.context.EndpointGateContext;
+import net.brightroom.endpointgate.core.rollout.DefaultRolloutStrategy;
+import net.brightroom.endpointgate.spring.webflux.context.ReactiveEndpointGateContextResolver;
+import net.brightroom.endpointgate.spring.webflux.filter.EndpointGateHandlerFilterFunction;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+/**
+ * Verifies rollout behavior for Functional Endpoints through the full WebFlux stack with a real
+ * Netty server:
+ *
+ * <ul>
+ *   <li>Custom {@link ReactiveEndpointGateContextResolver} bean is respected via
+ *       {@code @ConditionalOnMissingBean}, enabling sticky rollout.
+ *   <li>Rollout decision is deterministic for a fixed user identifier.
+ *   <li>{@link EndpointGateHandlerFilterFunction#of(String, int)} correctly applies rollout control
+ *       via {@code ServerRequest.exchange().getRequest()} in the real Netty pipeline.
+ * </ul>
+ *
+ * <p>A real Netty server is used (instead of {@code @WebFluxTest}) to ensure the full Spring
+ * WebFlux pipeline — including context propagation of {@code ServerWebExchange} — is exercised.
+ */
+@SpringBootTest(
+    webEnvironment = WebEnvironment.RANDOM_PORT,
+    properties = {"endpoint-gate.gates.rollout-feature.enabled=true"})
+class EndpointGateHandlerFilterFunctionRolloutIntegrationTest {
+
+  private static final EndpointGateContext FIXED_CONTEXT = new EndpointGateContext("fixed-user-id");
+  private static final boolean IN_ROLLOUT_50 =
+      new DefaultRolloutStrategy().isInRollout("rollout-feature", FIXED_CONTEXT, 50);
+
+  @TestConfiguration
+  static class FixedContextResolverConfig {
+    @Bean
+    ReactiveEndpointGateContextResolver contextResolver() {
+      return request -> Mono.just(FIXED_CONTEXT);
+    }
+  }
+
+  @TestConfiguration
+  static class RolloutRouteConfig {
+    @Bean
+    RouterFunction<ServerResponse> functionalRolloutTestRoute(
+        EndpointGateHandlerFilterFunction endpointGateFilter) {
+      return route()
+          .GET("/functional/rollout-test", req -> ServerResponse.ok().bodyValue("Allowed"))
+          .filter(endpointGateFilter.of("rollout-feature", 50))
+          .build();
+    }
+  }
+
+  @LocalServerPort int port;
+
+  WebTestClient webTestClient;
+
+  @BeforeEach
+  void setUp() {
+    webTestClient = WebTestClient.bindToServer().baseUrl("http://localhost:" + port).build();
+  }
+
+  @Test
+  void rollout_returnsDeterministicResult_forFixedUserId() {
+    if (IN_ROLLOUT_50) {
+      webTestClient.get().uri("/functional/rollout-test").exchange().expectStatus().isOk();
+    } else {
+      webTestClient.get().uri("/functional/rollout-test").exchange().expectStatus().isForbidden();
+    }
+  }
+
+  @Test
+  void rollout_sameUserAlwaysGetsSameResult() {
+    // Call twice — result must be identical (deterministic hashing)
+    for (int i = 0; i < 2; i++) {
+      if (IN_ROLLOUT_50) {
+        webTestClient.get().uri("/functional/rollout-test").exchange().expectStatus().isOk();
+      } else {
+        webTestClient.get().uri("/functional/rollout-test").exchange().expectStatus().isForbidden();
+      }
+    }
+  }
+
+  @Test
+  void rollout_returnsBody_whenInRollout() {
+    Assumptions.assumeTrue(IN_ROLLOUT_50, "User not in rollout bucket");
+    webTestClient
+        .get()
+        .uri("/functional/rollout-test")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateNettyIntegrationTest.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateNettyIntegrationTest.java
@@ -1,0 +1,61 @@
+package net.brightroom.endpointgate.spring.webflux;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class EndpointGateNettyIntegrationTest {
+
+  @LocalServerPort int port;
+
+  WebTestClient webTestClient;
+
+  @BeforeEach
+  void setUp() {
+    webTestClient = WebTestClient.bindToServer().baseUrl("http://localhost:" + port).build();
+  }
+
+  @Test
+  void shouldAllowAccess_whenGateIsEnabled() {
+    webTestClient
+        .get()
+        .uri("/experimental-stage-endpoint")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Test
+  void shouldBlockAccess_whenGateIsDisabled() {
+    webTestClient.get().uri("/development-stage-endpoint").exchange().expectStatus().isForbidden();
+  }
+
+  @Test
+  void shouldBlockAccess_whenFunctionalEndpointGateIsDisabled() {
+    webTestClient
+        .get()
+        .uri("/functional/development-stage-endpoint")
+        .exchange()
+        .expectStatus()
+        .isForbidden();
+  }
+
+  @Test
+  void shouldAllowAccess_whenRemoteAddressConditionIsSatisfied() {
+    // Real Netty server: remoteAddress resolves to 127.0.0.1 for localhost connections
+    webTestClient
+        .get()
+        .uri("/condition/remote-address")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/TestApplication.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/TestApplication.java
@@ -1,0 +1,6 @@
+package net.brightroom.endpointgate.spring.webflux;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+class TestApplication {}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/configuration/EndpointGateWebFluxTestAutoConfiguration.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/configuration/EndpointGateWebFluxTestAutoConfiguration.java
@@ -1,0 +1,29 @@
+package net.brightroom.endpointgate.spring.webflux.configuration;
+
+import net.brightroom.endpointgate.spring.core.autoconfigure.EndpointGateAutoConfiguration;
+import net.brightroom.endpointgate.spring.core.properties.EndpointGateProperties;
+import net.brightroom.endpointgate.spring.webflux.autoconfigure.EndpointGateWebFluxAutoConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Test auto-configuration for the webflux module.
+ *
+ * <p>{@code @EnableAutoConfiguration} loads {@code EndpointGateAutoConfiguration} from the core
+ * module via {@code
+ * META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports}. It also loads
+ * the webflux auto-configuration through the same mechanism, so the {@code @Import} below results
+ * in the webflux auto-configuration being registered twice. Spring handles this gracefully by
+ * deduplicating bean definitions with the same name.
+ *
+ * <p>{@code @Import} is kept here to make the dependency on the webflux auto-configuration explicit
+ * and to ensure it is loaded even if the {@code @EnableAutoConfiguration} scanning order changes in
+ * future Spring Boot versions.
+ */
+@Configuration
+@EnableAutoConfiguration
+@EnableConfigurationProperties(EndpointGateProperties.class)
+@Import({EndpointGateAutoConfiguration.class, EndpointGateWebFluxAutoConfiguration.class})
+public class EndpointGateWebFluxTestAutoConfiguration {}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/endpoint/EndpointGateClassRolloutController.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/endpoint/EndpointGateClassRolloutController.java
@@ -1,0 +1,18 @@
+package net.brightroom.endpointgate.spring.webflux.endpoint;
+
+import net.brightroom.endpointgate.core.annotation.EndpointGate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@EndpointGate("rollout-feature")
+public class EndpointGateClassRolloutController {
+
+  @GetMapping("/test/class-rollout")
+  public Mono<String> testClassRollout() {
+    return Mono.just("Allowed");
+  }
+
+  public EndpointGateClassRolloutController() {}
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/endpoint/EndpointGateConditionController.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/endpoint/EndpointGateConditionController.java
@@ -1,0 +1,36 @@
+package net.brightroom.endpointgate.spring.webflux.endpoint;
+
+import net.brightroom.endpointgate.core.annotation.EndpointGate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+public class EndpointGateConditionController {
+
+  @EndpointGate("header-condition-feature")
+  @GetMapping("/condition/header")
+  Mono<String> headerCondition() {
+    return Mono.just("Allowed");
+  }
+
+  @EndpointGate("param-condition-feature")
+  @GetMapping("/condition/param")
+  Mono<String> paramCondition() {
+    return Mono.just("Allowed");
+  }
+
+  @EndpointGate("condition-rollout-feature")
+  @GetMapping("/condition/with-rollout")
+  Mono<String> conditionWithRollout() {
+    return Mono.just("Allowed");
+  }
+
+  @EndpointGate("remote-address-condition-feature")
+  @GetMapping("/condition/remote-address")
+  Mono<String> remoteAddressCondition() {
+    return Mono.just("Allowed");
+  }
+
+  public EndpointGateConditionController() {}
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/endpoint/EndpointGateDisableController.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/endpoint/EndpointGateDisableController.java
@@ -1,0 +1,24 @@
+package net.brightroom.endpointgate.spring.webflux.endpoint;
+
+import net.brightroom.endpointgate.core.annotation.EndpointGate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@EndpointGate("disable-class-level-feature")
+public class EndpointGateDisableController {
+
+  @GetMapping("/test/disable")
+  Mono<String> testDisable() {
+    return Mono.just("Not Allowed");
+  }
+
+  @EndpointGate("experimental-stage-endpoint")
+  @GetMapping("/test/method-override")
+  Mono<String> testMethodOverride() {
+    return Mono.just("Method Override Allowed");
+  }
+
+  public EndpointGateDisableController() {}
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/endpoint/EndpointGateEnableController.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/endpoint/EndpointGateEnableController.java
@@ -1,0 +1,18 @@
+package net.brightroom.endpointgate.spring.webflux.endpoint;
+
+import net.brightroom.endpointgate.core.annotation.EndpointGate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@EndpointGate("enable-class-level-feature")
+public class EndpointGateEnableController {
+
+  @GetMapping("/test/enabled")
+  Mono<String> testEnabled() {
+    return Mono.just("Allowed");
+  }
+
+  public EndpointGateEnableController() {}
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/endpoint/EndpointGateMethodLevelController.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/endpoint/EndpointGateMethodLevelController.java
@@ -1,0 +1,29 @@
+package net.brightroom.endpointgate.spring.webflux.endpoint;
+
+import net.brightroom.endpointgate.core.annotation.EndpointGate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+public class EndpointGateMethodLevelController {
+
+  @GetMapping("/stable-endpoint")
+  Mono<String> stableEndpoint() {
+    return Mono.just("No Annotation");
+  }
+
+  @EndpointGate("experimental-stage-endpoint")
+  @GetMapping("/experimental-stage-endpoint")
+  Mono<String> experimentalStageEndpoint() {
+    return Mono.just("Allowed");
+  }
+
+  @EndpointGate("development-stage-endpoint")
+  @GetMapping("/development-stage-endpoint")
+  Mono<String> developmentStageEndpoint() {
+    return Mono.just("Not Allowed");
+  }
+
+  public EndpointGateMethodLevelController() {}
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/endpoint/EndpointGateRolloutController.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/endpoint/EndpointGateRolloutController.java
@@ -1,0 +1,18 @@
+package net.brightroom.endpointgate.spring.webflux.endpoint;
+
+import net.brightroom.endpointgate.core.annotation.EndpointGate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+public class EndpointGateRolloutController {
+
+  @GetMapping("/test/rollout")
+  @EndpointGate("rollout-feature")
+  public Mono<String> testRollout() {
+    return Mono.just("Allowed");
+  }
+
+  public EndpointGateRolloutController() {}
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/endpoint/EndpointGateRouterConfiguration.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/endpoint/EndpointGateRouterConfiguration.java
@@ -1,0 +1,86 @@
+package net.brightroom.endpointgate.spring.webflux.endpoint;
+
+import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
+import static org.springframework.web.reactive.function.server.RouterFunctions.route;
+
+import net.brightroom.endpointgate.spring.webflux.filter.EndpointGateHandlerFilterFunction;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+@Configuration
+public class EndpointGateRouterConfiguration {
+
+  private final EndpointGateHandlerFilterFunction endpointGateFilter;
+
+  @Bean
+  RouterFunction<ServerResponse> functionalStableRoute() {
+    return route(
+        GET("/functional/stable-endpoint"), req -> ServerResponse.ok().bodyValue("No Annotation"));
+  }
+
+  @Bean
+  RouterFunction<ServerResponse> functionalEnabledRoute() {
+    return route()
+        .GET(
+            "/functional/experimental-stage-endpoint",
+            req -> ServerResponse.ok().bodyValue("Allowed"))
+        .filter(endpointGateFilter.of("experimental-stage-endpoint"))
+        .build();
+  }
+
+  @Bean
+  RouterFunction<ServerResponse> functionalDisabledRoute() {
+    return route()
+        .GET(
+            "/functional/development-stage-endpoint",
+            req -> ServerResponse.ok().bodyValue("Not Allowed"))
+        .filter(endpointGateFilter.of("development-stage-endpoint"))
+        .build();
+  }
+
+  @Bean
+  RouterFunction<ServerResponse> functionalClassLevelDisabledRoute() {
+    return route()
+        .GET("/functional/test/disable", req -> ServerResponse.ok().bodyValue("Not Allowed"))
+        .filter(endpointGateFilter.of("disable-class-level-feature"))
+        .build();
+  }
+
+  @Bean
+  RouterFunction<ServerResponse> functionalClassLevelEnabledRoute() {
+    return route()
+        .GET("/functional/test/enabled", req -> ServerResponse.ok().bodyValue("Allowed"))
+        .filter(endpointGateFilter.of("enable-class-level-feature"))
+        .build();
+  }
+
+  @Bean
+  RouterFunction<ServerResponse> functionalUndefinedFlagRoute() {
+    return route()
+        .GET("/functional/undefined-flag-endpoint", req -> ServerResponse.ok().bodyValue("Allowed"))
+        .filter(endpointGateFilter.of("undefined-in-config-flag"))
+        .build();
+  }
+
+  @Bean
+  RouterFunction<ServerResponse> functionalConditionRoute() {
+    return route()
+        .GET("/functional/condition/header", req -> ServerResponse.ok().bodyValue("Allowed"))
+        .filter(endpointGateFilter.of("conditional-feature", "headers['X-Beta'] != null"))
+        .build();
+  }
+
+  @Bean
+  RouterFunction<ServerResponse> functionalConditionParamRoute() {
+    return route()
+        .GET("/functional/condition/param", req -> ServerResponse.ok().bodyValue("Allowed"))
+        .filter(endpointGateFilter.of("conditional-feature", "params['variant'] == 'B'"))
+        .build();
+  }
+
+  public EndpointGateRouterConfiguration(EndpointGateHandlerFilterFunction endpointGateFilter) {
+    this.endpointGateFilter = endpointGateFilter;
+  }
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/endpoint/EndpointGateUndefinedGateController.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/endpoint/EndpointGateUndefinedGateController.java
@@ -1,0 +1,25 @@
+package net.brightroom.endpointgate.spring.webflux.endpoint;
+
+import net.brightroom.endpointgate.core.annotation.EndpointGate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+/**
+ * Test controller for verifying fail-closed / fail-open behavior.
+ *
+ * <p>The gate {@code "undefined-in-config-flag"} is intentionally absent from {@code
+ * endpoint-gate.gates} in {@code application.yaml}, so its enabled state is determined solely by
+ * {@code endpoint-gate.default-enabled}.
+ */
+@RestController
+public class EndpointGateUndefinedGateController {
+
+  @EndpointGate("undefined-in-config-flag")
+  @GetMapping("/undefined-flag-endpoint")
+  Mono<String> undefinedFlagEndpoint() {
+    return Mono.just("Allowed");
+  }
+
+  public EndpointGateUndefinedGateController() {}
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/endpoint/NoEndpointGateController.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/endpoint/NoEndpointGateController.java
@@ -1,0 +1,16 @@
+package net.brightroom.endpointgate.spring.webflux.endpoint;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+public class NoEndpointGateController {
+
+  @GetMapping("/test/no-annotation")
+  Mono<String> noAnnotation() {
+    return Mono.just("No Annotation");
+  }
+
+  public NoEndpointGateController() {}
+}

--- a/spring/webflux/src/integrationTest/resources/application.yaml
+++ b/spring/webflux/src/integrationTest/resources/application.yaml
@@ -1,0 +1,17 @@
+endpoint-gate:
+  gates:
+    experimental-stage-endpoint:
+      enabled: true
+    development-stage-endpoint:
+      enabled: false
+    enable-class-level-feature:
+      enabled: true
+    disable-class-level-feature:
+      enabled: false
+    conditional-feature:
+      enabled: true
+    remote-address-condition-feature:
+      enabled: true
+      condition: "remoteAddress == '127.0.0.1'"
+  response:
+    type: json

--- a/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/aspect/EndpointGateAspect.java
+++ b/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/aspect/EndpointGateAspect.java
@@ -1,0 +1,182 @@
+package net.brightroom.endpointgate.spring.webflux.aspect;
+
+import java.lang.reflect.Method;
+import net.brightroom.endpointgate.core.annotation.EndpointGate;
+import net.brightroom.endpointgate.core.evaluation.AccessDecision;
+import net.brightroom.endpointgate.core.evaluation.EvaluationContext;
+import net.brightroom.endpointgate.core.exception.EndpointGateAccessDeniedException;
+import net.brightroom.endpointgate.reactive.core.evaluation.ReactiveEndpointGateEvaluationPipeline;
+import net.brightroom.endpointgate.reactive.core.provider.ReactiveConditionProvider;
+import net.brightroom.endpointgate.reactive.core.provider.ReactiveRolloutPercentageProvider;
+import net.brightroom.endpointgate.spring.webflux.condition.ServerHttpConditionVariables;
+import net.brightroom.endpointgate.spring.webflux.context.ReactiveEndpointGateContextResolver;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * AOP aspect that enforces endpoint gate access control on Spring WebFlux controller methods.
+ *
+ * <p>Intercepts methods and classes annotated with {@link
+ * net.brightroom.endpointgate.core.annotation.EndpointGate} via an {@code @Around} advice. If the
+ * referenced gate is disabled, a {@link
+ * net.brightroom.endpointgate.core.exception.EndpointGateAccessDeniedException} is emitted into the
+ * reactive pipeline. The method-level annotation takes priority over the class-level annotation.
+ *
+ * <p>Only reactive return types ({@link reactor.core.publisher.Mono} and {@link
+ * reactor.core.publisher.Flux}) are supported; non-reactive return types throw {@link
+ * IllegalStateException}.
+ */
+@Aspect
+public class EndpointGateAspect {
+
+  private final ReactiveEndpointGateEvaluationPipeline pipeline;
+  private final ReactiveEndpointGateContextResolver contextResolver;
+  private final ReactiveRolloutPercentageProvider rolloutPercentageProvider;
+  private final ReactiveConditionProvider conditionProvider;
+
+  /**
+   * Around advice that checks the endpoint gate before proceeding with the annotated method.
+   *
+   * <p>Applies to methods and classes annotated with {@link
+   * net.brightroom.endpointgate.core.annotation.EndpointGate}. If the gate is disabled, a {@link
+   * net.brightroom.endpointgate.core.exception.EndpointGateAccessDeniedException} is returned in
+   * the reactive pipeline. Rollout percentage and condition are also evaluated when configured.
+   *
+   * @param joinPoint the proceeding join point of the intercepted method
+   * @return the result of the intercepted method, or an error signal if access is denied
+   * @throws Throwable if the underlying method throws an exception
+   */
+  @Around(
+      "@within(net.brightroom.endpointgate.core.annotation.EndpointGate) || "
+          + "@annotation(net.brightroom.endpointgate.core.annotation.EndpointGate)")
+  public Object checkEndpointGate(ProceedingJoinPoint joinPoint) throws Throwable {
+    EndpointGate annotation = resolveAnnotation(joinPoint);
+    if (annotation == null) {
+      return joinPoint.proceed();
+    }
+
+    validateAnnotation(annotation);
+
+    String gateId = annotation.value();
+
+    Class<?> returnType = ((MethodSignature) joinPoint.getSignature()).getReturnType();
+
+    Mono<AccessDecision> decisionMono =
+        Mono.deferContextual(
+            ctx -> {
+              ServerWebExchange exchange = ctx.get(ServerWebExchange.class);
+              return Mono.zip(
+                      conditionProvider.getCondition(gateId).defaultIfEmpty(""),
+                      rolloutPercentageProvider.getRolloutPercentage(gateId).defaultIfEmpty(100),
+                      contextResolver
+                          .resolve(exchange.getRequest())
+                          .map(java.util.Optional::of)
+                          .defaultIfEmpty(java.util.Optional.empty()))
+                  .flatMap(
+                      tuple -> {
+                        EvaluationContext evalCtx =
+                            new EvaluationContext(
+                                gateId,
+                                tuple.getT1(),
+                                tuple.getT2(),
+                                ServerHttpConditionVariables.build(exchange.getRequest()),
+                                () -> tuple.getT3().orElse(null));
+                        return pipeline.evaluate(evalCtx);
+                      });
+            });
+
+    if (Mono.class.isAssignableFrom(returnType)) {
+      return decisionMono.flatMap(
+          decision -> {
+            if (decision instanceof AccessDecision.Denied denied) {
+              return Mono.error(new EndpointGateAccessDeniedException(denied.gateId()));
+            }
+            return proceedAsMono(joinPoint);
+          });
+    }
+
+    if (Flux.class.isAssignableFrom(returnType)) {
+      return decisionMono.flatMapMany(
+          decision -> {
+            if (decision instanceof AccessDecision.Denied denied) {
+              return Flux.error(new EndpointGateAccessDeniedException(denied.gateId()));
+            }
+            return proceedAsFlux(joinPoint);
+          });
+    }
+
+    throw new IllegalStateException(
+        "@EndpointGate on WebFlux controller method '"
+            + ((MethodSignature) joinPoint.getSignature()).getMethod().getName()
+            + "' requires a reactive return type (Mono or Flux). "
+            + "Non-reactive return types are not supported.");
+  }
+
+  @SuppressWarnings("unchecked")
+  private Mono<Object> proceedAsMono(ProceedingJoinPoint joinPoint) {
+    try {
+      return (Mono<Object>) joinPoint.proceed();
+    } catch (Throwable t) {
+      return Mono.error(t);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private Flux<Object> proceedAsFlux(ProceedingJoinPoint joinPoint) {
+    try {
+      return (Flux<Object>) joinPoint.proceed();
+    } catch (Throwable t) {
+      return Flux.error(t);
+    }
+  }
+
+  private EndpointGate resolveAnnotation(ProceedingJoinPoint joinPoint) {
+    MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+    Method method =
+        AopUtils.getMostSpecificMethod(
+            methodSignature.getMethod(), joinPoint.getTarget().getClass());
+    EndpointGate methodAnnotation = AnnotationUtils.findAnnotation(method, EndpointGate.class);
+    if (methodAnnotation != null) {
+      return methodAnnotation;
+    }
+    return AnnotationUtils.findAnnotation(joinPoint.getTarget().getClass(), EndpointGate.class);
+  }
+
+  private void validateAnnotation(EndpointGate annotation) {
+    if (annotation.value().isEmpty()) {
+      throw new IllegalStateException(
+          "@EndpointGate must specify a non-empty value. "
+              + "An empty value causes fail-open behavior and allows access unconditionally.");
+    }
+  }
+
+  /**
+   * Creates a new {@code EndpointGateAspect}.
+   *
+   * @param pipeline the reactive evaluation pipeline that performs all endpoint gate checks; must
+   *     not be null
+   * @param contextResolver the resolver used to extract context from the current request; must not
+   *     be null
+   * @param rolloutPercentageProvider the provider used to look up the rollout percentage per gate;
+   *     must not be null
+   * @param conditionProvider the provider used to look up the condition expression per gate; must
+   *     not be null
+   */
+  public EndpointGateAspect(
+      ReactiveEndpointGateEvaluationPipeline pipeline,
+      ReactiveEndpointGateContextResolver contextResolver,
+      ReactiveRolloutPercentageProvider rolloutPercentageProvider,
+      ReactiveConditionProvider conditionProvider) {
+    this.pipeline = pipeline;
+    this.contextResolver = contextResolver;
+    this.rolloutPercentageProvider = rolloutPercentageProvider;
+    this.conditionProvider = conditionProvider;
+  }
+}

--- a/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/autoconfigure/EndpointGateWebFluxAutoConfiguration.java
+++ b/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/autoconfigure/EndpointGateWebFluxAutoConfiguration.java
@@ -1,0 +1,229 @@
+package net.brightroom.endpointgate.spring.webflux.autoconfigure;
+
+import java.time.Clock;
+import net.brightroom.endpointgate.core.condition.EndpointGateConditionEvaluator;
+import net.brightroom.endpointgate.reactive.core.condition.ReactiveEndpointGateConditionEvaluator;
+import net.brightroom.endpointgate.reactive.core.evaluation.ReactiveConditionEvaluationStep;
+import net.brightroom.endpointgate.reactive.core.evaluation.ReactiveEnabledEvaluationStep;
+import net.brightroom.endpointgate.reactive.core.evaluation.ReactiveEndpointGateEvaluationPipeline;
+import net.brightroom.endpointgate.reactive.core.evaluation.ReactiveRolloutEvaluationStep;
+import net.brightroom.endpointgate.reactive.core.evaluation.ReactiveScheduleEvaluationStep;
+import net.brightroom.endpointgate.reactive.core.provider.InMemoryReactiveConditionProvider;
+import net.brightroom.endpointgate.reactive.core.provider.InMemoryReactiveEndpointGateProvider;
+import net.brightroom.endpointgate.reactive.core.provider.InMemoryReactiveRolloutPercentageProvider;
+import net.brightroom.endpointgate.reactive.core.provider.InMemoryReactiveScheduleProvider;
+import net.brightroom.endpointgate.reactive.core.provider.ReactiveConditionProvider;
+import net.brightroom.endpointgate.reactive.core.provider.ReactiveEndpointGateProvider;
+import net.brightroom.endpointgate.reactive.core.provider.ReactiveRolloutPercentageProvider;
+import net.brightroom.endpointgate.reactive.core.provider.ReactiveScheduleProvider;
+import net.brightroom.endpointgate.reactive.core.rollout.DefaultReactiveRolloutStrategy;
+import net.brightroom.endpointgate.reactive.core.rollout.ReactiveRolloutStrategy;
+import net.brightroom.endpointgate.spring.core.autoconfigure.EndpointGateAutoConfiguration;
+import net.brightroom.endpointgate.spring.core.condition.SpelEndpointGateConditionEvaluator;
+import net.brightroom.endpointgate.spring.core.condition.SpelReactiveEndpointGateConditionEvaluator;
+import net.brightroom.endpointgate.spring.core.properties.EndpointGateProperties;
+import net.brightroom.endpointgate.spring.webflux.aspect.EndpointGateAspect;
+import net.brightroom.endpointgate.spring.webflux.context.RandomReactiveEndpointGateContextResolver;
+import net.brightroom.endpointgate.spring.webflux.context.ReactiveEndpointGateContextResolver;
+import net.brightroom.endpointgate.spring.webflux.exception.EndpointGateExceptionHandler;
+import net.brightroom.endpointgate.spring.webflux.filter.EndpointGateHandlerFilterFunction;
+import net.brightroom.endpointgate.spring.webflux.resolution.exceptionhandler.AccessDeniedExceptionHandlerResolution;
+import net.brightroom.endpointgate.spring.webflux.resolution.exceptionhandler.AccessDeniedExceptionHandlerResolutionFactory;
+import net.brightroom.endpointgate.spring.webflux.resolution.handlerfilter.AccessDeniedHandlerFilterResolution;
+import net.brightroom.endpointgate.spring.webflux.resolution.handlerfilter.AccessDeniedHandlerFilterResolutionFactory;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+
+/**
+ * Auto-configuration for the Spring WebFlux endpoint gate integration.
+ *
+ * <p>Registers the following beans when running in a reactive web application:
+ *
+ * <ul>
+ *   <li>{@link ReactiveEndpointGateProvider} — in-memory provider backed by {@code
+ *       endpoint-gate.gates} config (conditional on missing bean)
+ *   <li>{@link EndpointGateAspect} — AOP aspect for annotation-based controllers (conditional on
+ *       missing bean)
+ *   <li>{@link EndpointGateHandlerFilterFunction} — filter factory for functional endpoints
+ *       (conditional on missing bean)
+ *   <li>{@link WebFilter} — propagates {@link ServerWebExchange} into the Reactor context
+ * </ul>
+ */
+@AutoConfiguration(after = EndpointGateAutoConfiguration.class)
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
+@EnableAspectJAutoProxy(proxyTargetClass = true)
+public class EndpointGateWebFluxAutoConfiguration {
+
+  private final EndpointGateProperties endpointGateProperties;
+
+  @Bean
+  @ConditionalOnMissingBean(ReactiveEndpointGateProvider.class)
+  ReactiveEndpointGateProvider reactiveEndpointGateProvider() {
+    return new InMemoryReactiveEndpointGateProvider(
+        endpointGateProperties.gateIds(), endpointGateProperties.defaultEnabled());
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  AccessDeniedExceptionHandlerResolution accessDeniedExceptionHandlerResolution() {
+    return new AccessDeniedExceptionHandlerResolutionFactory().create(endpointGateProperties);
+  }
+
+  @Bean
+  EndpointGateExceptionHandler endpointGateExceptionHandler(
+      AccessDeniedExceptionHandlerResolution accessDeniedExceptionHandlerResolution) {
+    return new EndpointGateExceptionHandler(accessDeniedExceptionHandlerResolution);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(ReactiveRolloutStrategy.class)
+  ReactiveRolloutStrategy reactiveRolloutStrategy() {
+    return new DefaultReactiveRolloutStrategy();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  ReactiveEndpointGateContextResolver reactiveEndpointGateContextResolver() {
+    return new RandomReactiveEndpointGateContextResolver();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(ReactiveRolloutPercentageProvider.class)
+  ReactiveRolloutPercentageProvider reactiveRolloutPercentageProvider() {
+    return new InMemoryReactiveRolloutPercentageProvider(
+        endpointGateProperties.rolloutPercentages());
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(ReactiveConditionProvider.class)
+  ReactiveConditionProvider reactiveConditionProvider() {
+    return new InMemoryReactiveConditionProvider(endpointGateProperties.conditions());
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  Clock endpointGateClock() {
+    return Clock.systemDefaultZone();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(ReactiveScheduleProvider.class)
+  ReactiveScheduleProvider reactiveScheduleProvider() {
+    return new InMemoryReactiveScheduleProvider(endpointGateProperties.schedules());
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  EndpointGateConditionEvaluator endpointGateConditionEvaluator() {
+    return new SpelEndpointGateConditionEvaluator(endpointGateProperties.condition().failOnError());
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(ReactiveEndpointGateConditionEvaluator.class)
+  ReactiveEndpointGateConditionEvaluator reactiveEndpointGateConditionEvaluator(
+      EndpointGateConditionEvaluator conditionEvaluator) {
+    return new SpelReactiveEndpointGateConditionEvaluator(conditionEvaluator);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(ReactiveEnabledEvaluationStep.class)
+  ReactiveEnabledEvaluationStep reactiveEnabledEvaluationStep(
+      ReactiveEndpointGateProvider reactiveEndpointGateProvider) {
+    return new ReactiveEnabledEvaluationStep(reactiveEndpointGateProvider);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(ReactiveScheduleEvaluationStep.class)
+  ReactiveScheduleEvaluationStep reactiveScheduleEvaluationStep(
+      ReactiveScheduleProvider reactiveScheduleProvider, Clock clock) {
+    return new ReactiveScheduleEvaluationStep(reactiveScheduleProvider, clock);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(ReactiveConditionEvaluationStep.class)
+  ReactiveConditionEvaluationStep reactiveConditionEvaluationStep(
+      ReactiveEndpointGateConditionEvaluator conditionEvaluator) {
+    return new ReactiveConditionEvaluationStep(conditionEvaluator);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(ReactiveRolloutEvaluationStep.class)
+  ReactiveRolloutEvaluationStep reactiveRolloutEvaluationStep(
+      ReactiveRolloutStrategy reactiveRolloutStrategy) {
+    return new ReactiveRolloutEvaluationStep(reactiveRolloutStrategy);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  ReactiveEndpointGateEvaluationPipeline reactiveEndpointGateEvaluationPipeline(
+      ReactiveEnabledEvaluationStep enabledStep,
+      ReactiveScheduleEvaluationStep scheduleStep,
+      ReactiveConditionEvaluationStep conditionStep,
+      ReactiveRolloutEvaluationStep rolloutStep) {
+    return new ReactiveEndpointGateEvaluationPipeline(
+        enabledStep, scheduleStep, conditionStep, rolloutStep);
+  }
+
+  /**
+   * Propagates {@link ServerWebExchange} into the Reactor context so that {@link
+   * EndpointGateAspect} can access it via {@code Mono.deferContextual} during rollout percentage
+   * checks.
+   *
+   * <p>Spring WebFlux does not automatically add {@link ServerWebExchange} to the Reactor context,
+   * so this filter bridges the gap between the servlet-style exchange object and the reactive
+   * context, enabling the aspect to resolve the request for sticky rollout without requiring
+   * constructor injection of the exchange.
+   */
+  @Bean
+  WebFilter endpointGateServerWebExchangeContextFilter() {
+    return (exchange, chain) ->
+        chain.filter(exchange).contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange));
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  EndpointGateAspect endpointGateAspect(
+      ReactiveEndpointGateEvaluationPipeline pipeline,
+      ReactiveEndpointGateContextResolver contextResolver,
+      ReactiveRolloutPercentageProvider reactiveRolloutPercentageProvider,
+      ReactiveConditionProvider reactiveConditionProvider) {
+    return new EndpointGateAspect(
+        pipeline, contextResolver, reactiveRolloutPercentageProvider, reactiveConditionProvider);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean(AccessDeniedHandlerFilterResolution.class)
+  AccessDeniedHandlerFilterResolution accessDeniedHandlerFilterResolution() {
+    return new AccessDeniedHandlerFilterResolutionFactory().create(endpointGateProperties);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  EndpointGateHandlerFilterFunction endpointGateHandlerFilterFunction(
+      ReactiveEndpointGateEvaluationPipeline pipeline,
+      AccessDeniedHandlerFilterResolution accessDeniedHandlerFilterResolution,
+      ReactiveRolloutPercentageProvider reactiveRolloutPercentageProvider,
+      ReactiveConditionProvider reactiveConditionProvider,
+      ReactiveEndpointGateContextResolver contextResolver) {
+    return new EndpointGateHandlerFilterFunction(
+        pipeline,
+        accessDeniedHandlerFilterResolution,
+        reactiveRolloutPercentageProvider,
+        reactiveConditionProvider,
+        contextResolver);
+  }
+
+  /**
+   * Creates a new {@code EndpointGateWebFluxAutoConfiguration}.
+   *
+   * @param endpointGateProperties the endpoint gate configuration properties
+   */
+  EndpointGateWebFluxAutoConfiguration(EndpointGateProperties endpointGateProperties) {
+    this.endpointGateProperties = endpointGateProperties;
+  }
+}

--- a/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/condition/ServerHttpConditionVariables.java
+++ b/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/condition/ServerHttpConditionVariables.java
@@ -1,0 +1,50 @@
+package net.brightroom.endpointgate.spring.webflux.condition;
+
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+import net.brightroom.endpointgate.core.condition.ConditionVariables;
+import net.brightroom.endpointgate.core.condition.ConditionVariablesBuilder;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+
+/**
+ * Utility for building the condition variables map from a {@link ServerHttpRequest}.
+ *
+ * <p>Shared by {@link net.brightroom.endpointgate.spring.webflux.aspect.EndpointGateAspect} and
+ * {@link net.brightroom.endpointgate.spring.webflux.filter.EndpointGateHandlerFilterFunction} to
+ * avoid duplication. Key names are defined by {@link ConditionVariablesBuilder}.
+ */
+public final class ServerHttpConditionVariables {
+
+  private ServerHttpConditionVariables() {}
+
+  /**
+   * Builds the condition variables from the given request.
+   *
+   * @param request the incoming reactive HTTP request
+   * @return the condition variables for the request
+   */
+  public static ConditionVariables build(ServerHttpRequest request) {
+    Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    request.getHeaders().forEach((name, values) -> headers.put(name, values.getFirst()));
+    Map<String, String> params = new HashMap<>();
+    request.getQueryParams().forEach((name, values) -> params.put(name, values.getFirst()));
+    Map<String, String> cookies = new HashMap<>();
+    request
+        .getCookies()
+        .forEach(
+            (name, cookieList) -> {
+              if (!cookieList.isEmpty()) cookies.put(name, cookieList.getFirst().getValue());
+            });
+    InetSocketAddress remoteAddr = request.getRemoteAddress();
+    return new ConditionVariablesBuilder()
+        .headers(headers)
+        .params(params)
+        .cookies(cookies)
+        .path(request.getPath().value())
+        .method(request.getMethod().name())
+        .remoteAddress(remoteAddr != null ? remoteAddr.getHostString() : "")
+        .build();
+  }
+}

--- a/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/context/RandomReactiveEndpointGateContextResolver.java
+++ b/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/context/RandomReactiveEndpointGateContextResolver.java
@@ -1,0 +1,27 @@
+package net.brightroom.endpointgate.spring.webflux.context;
+
+import java.util.UUID;
+import net.brightroom.endpointgate.core.context.EndpointGateContext;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import reactor.core.publisher.Mono;
+
+/**
+ * Default {@link ReactiveEndpointGateContextResolver} that generates a random UUID per request.
+ *
+ * <p>This provides non-sticky (per-request probabilistic) rollout behavior. Each request
+ * independently has a rollout-percentage chance of being included.
+ *
+ * <p>This is the default implementation registered by auto-configuration. Users interact with
+ * {@link ReactiveEndpointGateContextResolver} only.
+ */
+public class RandomReactiveEndpointGateContextResolver
+    implements ReactiveEndpointGateContextResolver {
+
+  /** Creates a new {@code RandomReactiveEndpointGateContextResolver}. */
+  public RandomReactiveEndpointGateContextResolver() {}
+
+  @Override
+  public Mono<EndpointGateContext> resolve(ServerHttpRequest request) {
+    return Mono.just(new EndpointGateContext(UUID.randomUUID().toString()));
+  }
+}

--- a/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/context/ReactiveEndpointGateContextResolver.java
+++ b/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/context/ReactiveEndpointGateContextResolver.java
@@ -1,0 +1,30 @@
+package net.brightroom.endpointgate.spring.webflux.context;
+
+import net.brightroom.endpointgate.core.context.EndpointGateContext;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import reactor.core.publisher.Mono;
+
+/**
+ * Resolves the endpoint gate context from the current reactive HTTP request.
+ *
+ * <p>The context is used for rollout percentage checks. The default implementation ({@link
+ * RandomReactiveEndpointGateContextResolver}) generates a random UUID per request, providing
+ * non-sticky (per-request probabilistic) rollout behavior.
+ *
+ * <p>To achieve sticky rollout (same user always gets the same result), implement this interface
+ * and register it as a {@code @Bean}. The custom bean will replace the default due to
+ * {@code @ConditionalOnMissingBean}.
+ *
+ * <p>Return {@link Mono#empty()} if the identifier cannot be resolved. In that case, the rollout
+ * check is skipped and the gate is treated as fully enabled (fail-open).
+ */
+public interface ReactiveEndpointGateContextResolver {
+
+  /**
+   * Resolves the endpoint gate context from the current request.
+   *
+   * @param request the current reactive HTTP request
+   * @return a {@link Mono} emitting the resolved context, or empty to skip the rollout check
+   */
+  Mono<EndpointGateContext> resolve(ServerHttpRequest request);
+}

--- a/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/exception/EndpointGateExceptionHandler.java
+++ b/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/exception/EndpointGateExceptionHandler.java
@@ -1,0 +1,43 @@
+package net.brightroom.endpointgate.spring.webflux.exception;
+
+import net.brightroom.endpointgate.core.exception.EndpointGateAccessDeniedException;
+import net.brightroom.endpointgate.spring.webflux.resolution.exceptionhandler.AccessDeniedExceptionHandlerResolution;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+/**
+ * Default handler for {@link EndpointGateAccessDeniedException}.
+ *
+ * <p>This handler has the lowest precedence ({@code @Order(Ordered.LOWEST_PRECEDENCE)}), so any
+ * user-defined {@code @ControllerAdvice} handling the same exception will take priority.
+ *
+ * <p>If you want to guarantee that your {@code @ControllerAdvice} takes priority, annotate it with
+ * an order value lower than {@code Ordered.LOWEST_PRECEDENCE} (e.g.,
+ * {@code @Order(Ordered.LOWEST_PRECEDENCE - 1)} or simply {@code @Order(0)}).
+ */
+@ControllerAdvice
+@Order(Ordered.LOWEST_PRECEDENCE)
+public class EndpointGateExceptionHandler {
+
+  private final AccessDeniedExceptionHandlerResolution accessDeniedExceptionHandlerResolution;
+
+  @ExceptionHandler(EndpointGateAccessDeniedException.class)
+  ResponseEntity<?> handleEndpointGateAccessDenied(
+      ServerHttpRequest request, EndpointGateAccessDeniedException e) {
+    return accessDeniedExceptionHandlerResolution.resolution(request, e);
+  }
+
+  /**
+   * Creates a new {@code EndpointGateExceptionHandler}.
+   *
+   * @param accessDeniedExceptionHandlerResolution the resolution used to build the denied response
+   */
+  public EndpointGateExceptionHandler(
+      AccessDeniedExceptionHandlerResolution accessDeniedExceptionHandlerResolution) {
+    this.accessDeniedExceptionHandlerResolution = accessDeniedExceptionHandlerResolution;
+  }
+}

--- a/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/filter/EndpointGateHandlerFilterFunction.java
+++ b/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/filter/EndpointGateHandlerFilterFunction.java
@@ -1,0 +1,189 @@
+package net.brightroom.endpointgate.spring.webflux.filter;
+
+import net.brightroom.endpointgate.core.evaluation.AccessDecision;
+import net.brightroom.endpointgate.core.evaluation.EvaluationContext;
+import net.brightroom.endpointgate.core.exception.EndpointGateAccessDeniedException;
+import net.brightroom.endpointgate.reactive.core.evaluation.ReactiveEndpointGateEvaluationPipeline;
+import net.brightroom.endpointgate.reactive.core.provider.ReactiveConditionProvider;
+import net.brightroom.endpointgate.reactive.core.provider.ReactiveRolloutPercentageProvider;
+import net.brightroom.endpointgate.spring.webflux.condition.ServerHttpConditionVariables;
+import net.brightroom.endpointgate.spring.webflux.context.ReactiveEndpointGateContextResolver;
+import net.brightroom.endpointgate.spring.webflux.resolution.handlerfilter.AccessDeniedHandlerFilterResolution;
+import org.springframework.web.reactive.function.server.HandlerFilterFunction;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+/**
+ * A factory for {@link HandlerFilterFunction} that applies endpoint gate access control to
+ * Functional Endpoints.
+ *
+ * <p>Use {@link #of(String)} to create a {@link HandlerFilterFunction} for a specific gate ID and
+ * apply it to a {@link org.springframework.web.reactive.function.server.RouterFunction}:
+ *
+ * <pre>{@code
+ * @Bean
+ * RouterFunction<ServerResponse> routes(EndpointGateHandlerFilterFunction endpointGateFilter) {
+ *     return route()
+ *         .GET("/api/gate", handler::handle)
+ *         .filter(endpointGateFilter.of("my-gate"))
+ *         .build();
+ * }
+ * }</pre>
+ *
+ * <p>When the gate is disabled, the filter delegates to {@link AccessDeniedHandlerFilterResolution}
+ * to build the denied response without invoking the handler. The default response format follows
+ * {@code endpoint-gate.response.type} configuration, and can be customized by providing a custom
+ * {@link AccessDeniedHandlerFilterResolution} bean.
+ *
+ * <p>Use {@link #of(String, int)} to enable gradual rollout for functional endpoints with a
+ * fallback rollout percentage.
+ */
+public class EndpointGateHandlerFilterFunction {
+
+  private final ReactiveEndpointGateEvaluationPipeline pipeline;
+  private final AccessDeniedHandlerFilterResolution resolution;
+  private final ReactiveRolloutPercentageProvider rolloutPercentageProvider;
+  private final ReactiveConditionProvider conditionProvider;
+  private final ReactiveEndpointGateContextResolver contextResolver;
+
+  /**
+   * Creates a {@link HandlerFilterFunction} that guards the route with the specified gate.
+   *
+   * <p>Condition and rollout percentage are resolved from the configured providers.
+   *
+   * @param gateId the identifier of the gate to check; must not be null or blank
+   * @return a {@link HandlerFilterFunction} that allows or denies access based on the gate
+   * @throws IllegalArgumentException if {@code gateId} is null or blank
+   */
+  public HandlerFilterFunction<ServerResponse, ServerResponse> of(String gateId) {
+    return of(gateId, "", 100);
+  }
+
+  /**
+   * Creates a {@link HandlerFilterFunction} that guards the route with the specified gate and
+   * fallback condition expression.
+   *
+   * <p>The condition is resolved from the provider first; the {@code conditionFallback} is used
+   * only when the provider returns no value for the gate.
+   *
+   * @param gateId the identifier of the gate to check; must not be null or blank
+   * @param conditionFallback SpEL expression used as fallback when the provider has no condition
+   *     configured; empty string means no condition
+   * @return a {@link HandlerFilterFunction} that allows or denies access based on the gate and
+   *     condition
+   * @throws IllegalArgumentException if {@code gateId} is null or blank
+   */
+  public HandlerFilterFunction<ServerResponse, ServerResponse> of(
+      String gateId, String conditionFallback) {
+    return of(gateId, conditionFallback, 100);
+  }
+
+  /**
+   * Creates a {@link HandlerFilterFunction} that guards the route with the specified gate and
+   * fallback rollout percentage.
+   *
+   * <p>The rollout percentage is resolved from the provider first; the {@code rolloutFallback} is
+   * used only when the provider returns no value for the gate.
+   *
+   * @param gateId the identifier of the gate to check; must not be null or blank
+   * @param rolloutFallback the fallback rollout percentage (0–100) when no value is configured in
+   *     the provider; 100 means fully enabled
+   * @return a {@link HandlerFilterFunction} that allows or denies access based on the gate and
+   *     rollout
+   * @throws IllegalArgumentException if {@code gateId} is null or blank, or if {@code
+   *     rolloutFallback} is not between 0 and 100
+   */
+  public HandlerFilterFunction<ServerResponse, ServerResponse> of(
+      String gateId, int rolloutFallback) {
+    return of(gateId, "", rolloutFallback);
+  }
+
+  /**
+   * Creates a {@link HandlerFilterFunction} that guards the route with the specified gate, fallback
+   * SpEL condition expression, and fallback rollout percentage.
+   *
+   * <p>The condition and rollout percentage are resolved from their respective providers first;
+   * fallback values are used only when the providers return no value for the gate.
+   *
+   * <p>The evaluation order is: gate enabled check → schedule check → condition check → rollout
+   * check.
+   *
+   * @param gateId the identifier of the gate to check; must not be null or blank
+   * @param conditionFallback SpEL expression used as fallback when the provider has no condition
+   *     configured; empty string means no condition
+   * @param rolloutFallback the fallback rollout percentage (0–100) when no value is configured in
+   *     the provider; 100 means fully enabled
+   * @return a {@link HandlerFilterFunction} that allows or denies access based on the gate,
+   *     condition, and rollout
+   * @throws IllegalArgumentException if {@code gateId} is null or blank, or if {@code
+   *     rolloutFallback} is not between 0 and 100
+   */
+  public HandlerFilterFunction<ServerResponse, ServerResponse> of(
+      String gateId, String conditionFallback, int rolloutFallback) {
+    if (gateId == null || gateId.isBlank()) {
+      throw new IllegalArgumentException(
+          "gateId must not be null or blank. "
+              + "A blank value causes fail-open behavior and allows access unconditionally.");
+    }
+    if (rolloutFallback < 0 || rolloutFallback > 100) {
+      throw new IllegalArgumentException(
+          "rollout must be between 0 and 100, but was: " + rolloutFallback);
+    }
+    return (request, next) ->
+        Mono.zip(
+                conditionProvider.getCondition(gateId).defaultIfEmpty(conditionFallback),
+                rolloutPercentageProvider
+                    .getRolloutPercentage(gateId)
+                    .defaultIfEmpty(rolloutFallback),
+                contextResolver
+                    .resolve(request.exchange().getRequest())
+                    .map(java.util.Optional::of)
+                    .defaultIfEmpty(java.util.Optional.empty()))
+            .flatMap(
+                tuple -> {
+                  EvaluationContext evalCtx =
+                      new EvaluationContext(
+                          gateId,
+                          tuple.getT1(),
+                          tuple.getT2(),
+                          ServerHttpConditionVariables.build(request.exchange().getRequest()),
+                          () -> tuple.getT3().orElse(null));
+                  return pipeline.evaluate(evalCtx);
+                })
+            .flatMap(
+                decision -> {
+                  if (decision instanceof AccessDecision.Denied denied) {
+                    return resolution.resolve(
+                        request, new EndpointGateAccessDeniedException(denied.gateId()));
+                  }
+                  return next.handle(request);
+                });
+  }
+
+  /**
+   * Creates a new {@code EndpointGateHandlerFilterFunction}.
+   *
+   * @param pipeline the reactive evaluation pipeline that performs all endpoint gate checks; must
+   *     not be null
+   * @param resolution the resolution used to build the denied response for functional endpoints;
+   *     must not be null
+   * @param rolloutPercentageProvider the provider used to look up the rollout percentage per gate;
+   *     must not be null
+   * @param conditionProvider the provider used to look up the condition expression per gate; must
+   *     not be null
+   * @param contextResolver the resolver used to extract context from the current request; must not
+   *     be null
+   */
+  public EndpointGateHandlerFilterFunction(
+      ReactiveEndpointGateEvaluationPipeline pipeline,
+      AccessDeniedHandlerFilterResolution resolution,
+      ReactiveRolloutPercentageProvider rolloutPercentageProvider,
+      ReactiveConditionProvider conditionProvider,
+      ReactiveEndpointGateContextResolver contextResolver) {
+    this.pipeline = pipeline;
+    this.resolution = resolution;
+    this.rolloutPercentageProvider = rolloutPercentageProvider;
+    this.conditionProvider = conditionProvider;
+    this.contextResolver = contextResolver;
+  }
+}

--- a/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/resolution/exceptionhandler/AccessDeniedExceptionHandlerResolution.java
+++ b/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/resolution/exceptionhandler/AccessDeniedExceptionHandlerResolution.java
@@ -1,0 +1,24 @@
+package net.brightroom.endpointgate.spring.webflux.resolution.exceptionhandler;
+
+import net.brightroom.endpointgate.core.exception.EndpointGateAccessDeniedException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+
+/**
+ * Interface for handling cases where access to an endpoint gate protected resource is denied in a
+ * {@link org.springframework.web.bind.annotation.ControllerAdvice} context.
+ *
+ * <p>Implementations return a {@link ResponseEntity} which is written through Spring's response
+ * processing pipeline, enabling content negotiation and standard message converters.
+ */
+public interface AccessDeniedExceptionHandlerResolution {
+
+  /**
+   * Resolves the response when access to an endpoint gate protected resource is denied.
+   *
+   * @param request the reactive HTTP request that was denied access
+   * @param e the EndpointGateAccessDeniedException that triggered the resolution
+   * @return a ResponseEntity representing the denial response
+   */
+  ResponseEntity<?> resolution(ServerHttpRequest request, EndpointGateAccessDeniedException e);
+}

--- a/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/resolution/exceptionhandler/AccessDeniedExceptionHandlerResolutionFactory.java
+++ b/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/resolution/exceptionhandler/AccessDeniedExceptionHandlerResolutionFactory.java
@@ -1,0 +1,34 @@
+package net.brightroom.endpointgate.spring.webflux.resolution.exceptionhandler;
+
+import net.brightroom.endpointgate.spring.core.properties.EndpointGateProperties;
+import net.brightroom.endpointgate.spring.core.properties.ResponseProperties;
+
+/**
+ * Factory for creating {@link AccessDeniedExceptionHandlerResolution} instances.
+ *
+ * <p>Selects the appropriate resolution implementation based on the configured {@code
+ * endpoint-gate.response.type} property.
+ */
+public class AccessDeniedExceptionHandlerResolutionFactory {
+
+  /**
+   * Creates an {@link AccessDeniedExceptionHandlerResolution} based on the response type configured
+   * in the given {@link EndpointGateProperties}.
+   *
+   * @param endpointGateProperties the endpoint gate configuration properties
+   * @return the resolution implementation matching the configured response type
+   */
+  public AccessDeniedExceptionHandlerResolution create(
+      EndpointGateProperties endpointGateProperties) {
+    ResponseProperties responseProperties = endpointGateProperties.response();
+
+    return switch (responseProperties.type()) {
+      case PLAIN_TEXT -> new AccessDeniedExceptionHandlerResolutionViaPlainTextResponse();
+      case HTML -> new AccessDeniedExceptionHandlerResolutionViaHtmlResponse();
+      case JSON -> new AccessDeniedExceptionHandlerResolutionViaJsonResponse();
+    };
+  }
+
+  /** Creates a new {@code AccessDeniedExceptionHandlerResolutionFactory}. */
+  public AccessDeniedExceptionHandlerResolutionFactory() {}
+}

--- a/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/resolution/exceptionhandler/AccessDeniedExceptionHandlerResolutionViaHtmlResponse.java
+++ b/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/resolution/exceptionhandler/AccessDeniedExceptionHandlerResolutionViaHtmlResponse.java
@@ -1,0 +1,26 @@
+package net.brightroom.endpointgate.spring.webflux.resolution.exceptionhandler;
+
+import java.nio.charset.StandardCharsets;
+import net.brightroom.endpointgate.core.exception.EndpointGateAccessDeniedException;
+import net.brightroom.endpointgate.spring.core.resolution.HtmlResponseBuilder;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+
+class AccessDeniedExceptionHandlerResolutionViaHtmlResponse
+    implements AccessDeniedExceptionHandlerResolution {
+
+  private static final MediaType TEXT_HTML_UTF8 =
+      new MediaType(MediaType.TEXT_HTML, StandardCharsets.UTF_8);
+
+  @Override
+  public ResponseEntity<?> resolution(
+      @SuppressWarnings("unused") ServerHttpRequest request, EndpointGateAccessDeniedException e) {
+    return ResponseEntity.status(HttpStatus.FORBIDDEN)
+        .contentType(TEXT_HTML_UTF8)
+        .body(HtmlResponseBuilder.buildHtml(e));
+  }
+
+  AccessDeniedExceptionHandlerResolutionViaHtmlResponse() {}
+}

--- a/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/resolution/exceptionhandler/AccessDeniedExceptionHandlerResolutionViaJsonResponse.java
+++ b/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/resolution/exceptionhandler/AccessDeniedExceptionHandlerResolutionViaJsonResponse.java
@@ -1,0 +1,23 @@
+package net.brightroom.endpointgate.spring.webflux.resolution.exceptionhandler;
+
+import net.brightroom.endpointgate.core.exception.EndpointGateAccessDeniedException;
+import net.brightroom.endpointgate.spring.core.resolution.ProblemDetailBuilder;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+
+class AccessDeniedExceptionHandlerResolutionViaJsonResponse
+    implements AccessDeniedExceptionHandlerResolution {
+
+  @Override
+  public ResponseEntity<?> resolution(
+      ServerHttpRequest request, EndpointGateAccessDeniedException e) {
+    var body = ProblemDetailBuilder.build(request.getPath().value(), e);
+    return ResponseEntity.status(HttpStatus.FORBIDDEN)
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .body(body);
+  }
+
+  AccessDeniedExceptionHandlerResolutionViaJsonResponse() {}
+}

--- a/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/resolution/exceptionhandler/AccessDeniedExceptionHandlerResolutionViaPlainTextResponse.java
+++ b/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/resolution/exceptionhandler/AccessDeniedExceptionHandlerResolutionViaPlainTextResponse.java
@@ -1,0 +1,25 @@
+package net.brightroom.endpointgate.spring.webflux.resolution.exceptionhandler;
+
+import java.nio.charset.StandardCharsets;
+import net.brightroom.endpointgate.core.exception.EndpointGateAccessDeniedException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+
+class AccessDeniedExceptionHandlerResolutionViaPlainTextResponse
+    implements AccessDeniedExceptionHandlerResolution {
+
+  private static final MediaType TEXT_PLAIN_UTF8 =
+      new MediaType(MediaType.TEXT_PLAIN, StandardCharsets.UTF_8);
+
+  @Override
+  public ResponseEntity<?> resolution(
+      @SuppressWarnings("unused") ServerHttpRequest request, EndpointGateAccessDeniedException e) {
+    return ResponseEntity.status(HttpStatus.FORBIDDEN)
+        .contentType(TEXT_PLAIN_UTF8)
+        .body(e.getMessage());
+  }
+
+  AccessDeniedExceptionHandlerResolutionViaPlainTextResponse() {}
+}

--- a/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/resolution/handlerfilter/AccessDeniedHandlerFilterResolution.java
+++ b/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/resolution/handlerfilter/AccessDeniedHandlerFilterResolution.java
@@ -1,0 +1,38 @@
+package net.brightroom.endpointgate.spring.webflux.resolution.handlerfilter;
+
+import net.brightroom.endpointgate.core.exception.EndpointGateAccessDeniedException;
+import org.springframework.web.reactive.function.server.HandlerFilterFunction;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+/**
+ * Interface for handling cases where access to an endpoint gate protected resource is denied in a
+ * {@link HandlerFilterFunction} context.
+ *
+ * <p>Implementations return a {@link ServerResponse} that the functional web framework writes to
+ * the client, rather than writing to the response directly.
+ *
+ * <p>To customize the denied response, implement this interface and register it as a {@code @Bean}.
+ * The custom bean takes priority over the library's default implementation due to
+ * {@code @ConditionalOnMissingBean}:
+ *
+ * <pre>{@code
+ * @Bean
+ * AccessDeniedHandlerFilterResolution myResolution() {
+ *     return (request, e) -> ServerResponse.status(HttpStatus.FORBIDDEN)
+ *         .bodyValue("Access denied: " + e.gateId());
+ * }
+ * }</pre>
+ */
+public interface AccessDeniedHandlerFilterResolution {
+
+  /**
+   * Resolves the response when access to an endpoint gate protected resource is denied.
+   *
+   * @param request the current server request
+   * @param e the EndpointGateAccessDeniedException that triggered the resolution
+   * @return a {@link Mono} emitting the {@link ServerResponse} to send to the client
+   */
+  Mono<ServerResponse> resolve(ServerRequest request, EndpointGateAccessDeniedException e);
+}

--- a/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/resolution/handlerfilter/AccessDeniedHandlerFilterResolutionFactory.java
+++ b/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/resolution/handlerfilter/AccessDeniedHandlerFilterResolutionFactory.java
@@ -1,0 +1,33 @@
+package net.brightroom.endpointgate.spring.webflux.resolution.handlerfilter;
+
+import net.brightroom.endpointgate.spring.core.properties.EndpointGateProperties;
+import net.brightroom.endpointgate.spring.core.properties.ResponseProperties;
+
+/**
+ * Factory for creating {@link AccessDeniedHandlerFilterResolution} instances.
+ *
+ * <p>Selects the appropriate resolution implementation based on the configured {@code
+ * endpoint-gate.response.type} property.
+ */
+public class AccessDeniedHandlerFilterResolutionFactory {
+
+  /**
+   * Creates an {@link AccessDeniedHandlerFilterResolution} based on the response type configured in
+   * the given {@link EndpointGateProperties}.
+   *
+   * @param endpointGateProperties the endpoint gate configuration properties
+   * @return the resolution implementation matching the configured response type
+   */
+  public AccessDeniedHandlerFilterResolution create(EndpointGateProperties endpointGateProperties) {
+    ResponseProperties responseProperties = endpointGateProperties.response();
+
+    return switch (responseProperties.type()) {
+      case PLAIN_TEXT -> new AccessDeniedHandlerFilterResolutionViaPlainTextResponse();
+      case HTML -> new AccessDeniedHandlerFilterResolutionViaHtmlResponse();
+      case JSON -> new AccessDeniedHandlerFilterResolutionViaJsonResponse();
+    };
+  }
+
+  /** Creates a new {@code AccessDeniedHandlerFilterResolutionFactory}. */
+  public AccessDeniedHandlerFilterResolutionFactory() {}
+}

--- a/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/resolution/handlerfilter/AccessDeniedHandlerFilterResolutionViaHtmlResponse.java
+++ b/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/resolution/handlerfilter/AccessDeniedHandlerFilterResolutionViaHtmlResponse.java
@@ -1,0 +1,31 @@
+package net.brightroom.endpointgate.spring.webflux.resolution.handlerfilter;
+
+import java.nio.charset.StandardCharsets;
+import net.brightroom.endpointgate.core.exception.EndpointGateAccessDeniedException;
+import net.brightroom.endpointgate.spring.core.resolution.HtmlResponseBuilder;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+class AccessDeniedHandlerFilterResolutionViaHtmlResponse
+    implements AccessDeniedHandlerFilterResolution {
+
+  private static final MediaType TEXT_HTML_UTF8 =
+      new MediaType(MediaType.TEXT_HTML, StandardCharsets.UTF_8);
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Note: the {@code request} parameter is not used in this implementation.
+   */
+  @Override
+  public Mono<ServerResponse> resolve(ServerRequest request, EndpointGateAccessDeniedException e) {
+    return ServerResponse.status(HttpStatus.FORBIDDEN)
+        .contentType(TEXT_HTML_UTF8)
+        .bodyValue(HtmlResponseBuilder.buildHtml(e));
+  }
+
+  AccessDeniedHandlerFilterResolutionViaHtmlResponse() {}
+}

--- a/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/resolution/handlerfilter/AccessDeniedHandlerFilterResolutionViaJsonResponse.java
+++ b/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/resolution/handlerfilter/AccessDeniedHandlerFilterResolutionViaJsonResponse.java
@@ -1,0 +1,23 @@
+package net.brightroom.endpointgate.spring.webflux.resolution.handlerfilter;
+
+import net.brightroom.endpointgate.core.exception.EndpointGateAccessDeniedException;
+import net.brightroom.endpointgate.spring.core.resolution.ProblemDetailBuilder;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+class AccessDeniedHandlerFilterResolutionViaJsonResponse
+    implements AccessDeniedHandlerFilterResolution {
+
+  @Override
+  public Mono<ServerResponse> resolve(ServerRequest request, EndpointGateAccessDeniedException e) {
+    var body = ProblemDetailBuilder.build(request.path(), e);
+    return ServerResponse.status(HttpStatus.FORBIDDEN)
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .bodyValue(body);
+  }
+
+  AccessDeniedHandlerFilterResolutionViaJsonResponse() {}
+}

--- a/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/resolution/handlerfilter/AccessDeniedHandlerFilterResolutionViaPlainTextResponse.java
+++ b/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/resolution/handlerfilter/AccessDeniedHandlerFilterResolutionViaPlainTextResponse.java
@@ -1,0 +1,30 @@
+package net.brightroom.endpointgate.spring.webflux.resolution.handlerfilter;
+
+import java.nio.charset.StandardCharsets;
+import net.brightroom.endpointgate.core.exception.EndpointGateAccessDeniedException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+class AccessDeniedHandlerFilterResolutionViaPlainTextResponse
+    implements AccessDeniedHandlerFilterResolution {
+
+  private static final MediaType TEXT_PLAIN_UTF8 =
+      new MediaType(MediaType.TEXT_PLAIN, StandardCharsets.UTF_8);
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Note: the {@code request} parameter is not used in this implementation.
+   */
+  @Override
+  public Mono<ServerResponse> resolve(ServerRequest request, EndpointGateAccessDeniedException e) {
+    return ServerResponse.status(HttpStatus.FORBIDDEN)
+        .contentType(TEXT_PLAIN_UTF8)
+        .bodyValue(e.getMessage());
+  }
+
+  AccessDeniedHandlerFilterResolutionViaPlainTextResponse() {}
+}

--- a/spring/webflux/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring/webflux/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+net.brightroom.endpointgate.spring.webflux.autoconfigure.EndpointGateWebFluxAutoConfiguration

--- a/spring/webflux/src/test/java/net/brightroom/endpointgate/spring/webflux/aspect/EndpointGateAspectTest.java
+++ b/spring/webflux/src/test/java/net/brightroom/endpointgate/spring/webflux/aspect/EndpointGateAspectTest.java
@@ -1,0 +1,790 @@
+package net.brightroom.endpointgate.spring.webflux.aspect;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import net.brightroom.endpointgate.core.annotation.EndpointGate;
+import net.brightroom.endpointgate.core.context.EndpointGateContext;
+import net.brightroom.endpointgate.core.exception.EndpointGateAccessDeniedException;
+import net.brightroom.endpointgate.core.provider.Schedule;
+import net.brightroom.endpointgate.reactive.core.condition.ReactiveEndpointGateConditionEvaluator;
+import net.brightroom.endpointgate.reactive.core.evaluation.ReactiveConditionEvaluationStep;
+import net.brightroom.endpointgate.reactive.core.evaluation.ReactiveEnabledEvaluationStep;
+import net.brightroom.endpointgate.reactive.core.evaluation.ReactiveEndpointGateEvaluationPipeline;
+import net.brightroom.endpointgate.reactive.core.evaluation.ReactiveRolloutEvaluationStep;
+import net.brightroom.endpointgate.reactive.core.evaluation.ReactiveScheduleEvaluationStep;
+import net.brightroom.endpointgate.reactive.core.provider.ReactiveConditionProvider;
+import net.brightroom.endpointgate.reactive.core.provider.ReactiveEndpointGateProvider;
+import net.brightroom.endpointgate.reactive.core.provider.ReactiveRolloutPercentageProvider;
+import net.brightroom.endpointgate.reactive.core.provider.ReactiveScheduleProvider;
+import net.brightroom.endpointgate.reactive.core.rollout.DefaultReactiveRolloutStrategy;
+import net.brightroom.endpointgate.reactive.core.rollout.ReactiveRolloutStrategy;
+import net.brightroom.endpointgate.spring.webflux.context.ReactiveEndpointGateContextResolver;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class EndpointGateAspectTest {
+
+  private final ReactiveEndpointGateProvider provider = mock(ReactiveEndpointGateProvider.class);
+  private final ReactiveEndpointGateContextResolver contextResolver =
+      mock(ReactiveEndpointGateContextResolver.class, invocation -> Mono.empty());
+  private final ReactiveRolloutPercentageProvider rolloutPercentageProvider =
+      mock(ReactiveRolloutPercentageProvider.class, invocation -> Mono.empty());
+  private final ReactiveConditionProvider conditionProvider =
+      mock(ReactiveConditionProvider.class, invocation -> Mono.empty());
+  private final ReactiveEndpointGateConditionEvaluator conditionEvaluator =
+      mock(ReactiveEndpointGateConditionEvaluator.class);
+  private final ReactiveScheduleProvider reactiveScheduleProvider =
+      mock(ReactiveScheduleProvider.class, invocation -> Mono.empty());
+  private final ReactiveRolloutStrategy rolloutStrategy = mock(ReactiveRolloutStrategy.class);
+
+  private ReactiveEndpointGateEvaluationPipeline buildPipeline(ReactiveRolloutStrategy strategy) {
+    return new ReactiveEndpointGateEvaluationPipeline(
+        new ReactiveEnabledEvaluationStep(provider),
+        new ReactiveScheduleEvaluationStep(reactiveScheduleProvider, Clock.systemDefaultZone()),
+        new ReactiveConditionEvaluationStep(conditionEvaluator),
+        new ReactiveRolloutEvaluationStep(strategy));
+  }
+
+  private final EndpointGateAspect aspect =
+      new EndpointGateAspect(
+          buildPipeline(new DefaultReactiveRolloutStrategy()),
+          contextResolver,
+          rolloutPercentageProvider,
+          conditionProvider);
+
+  private final EndpointGateAspect aspectWithRollout =
+      new EndpointGateAspect(
+          buildPipeline(rolloutStrategy),
+          contextResolver,
+          rolloutPercentageProvider,
+          conditionProvider);
+
+  private ServerWebExchange mockExchange() {
+    ServerWebExchange exchange = mock(ServerWebExchange.class);
+    ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);
+    when(exchange.getRequest()).thenReturn(httpRequest);
+    stubRequestForConditionVariables(httpRequest);
+    return exchange;
+  }
+
+  static class TestController {
+
+    @EndpointGate("")
+    public Mono<String> emptyAnnotationMethod() {
+      return Mono.just("ok");
+    }
+
+    @EndpointGate("some-feature")
+    public String nonReactiveMethod() {
+      return "non-reactive";
+    }
+
+    @EndpointGate("some-feature")
+    public Mono<String> monoMethod() {
+      return Mono.just("result");
+    }
+
+    @EndpointGate("some-feature")
+    public Flux<String> fluxMethod() {
+      return Flux.just("result1", "result2");
+    }
+
+    @EndpointGate("some-feature")
+    public Mono<String> rolloutMonoMethod() {
+      return Mono.just("result");
+    }
+
+    @EndpointGate("some-feature")
+    public Flux<String> rolloutFluxMethod() {
+      return Flux.just("result1", "result2");
+    }
+
+    @EndpointGate("some-feature")
+    public Mono<String> conditionMonoMethod() {
+      return Mono.just("result");
+    }
+
+    @EndpointGate("some-feature")
+    public Flux<String> conditionFluxMethod() {
+      return Flux.just("result1", "result2");
+    }
+  }
+
+  static class NoAnnotationController {
+
+    public Mono<String> noAnnotationMethod() {
+      return Mono.just("no-annotation");
+    }
+  }
+
+  // --- checkSchedule for Mono ---
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void checkEndpointGate_emitsError_whenScheduleIsInactive_forMono() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("monoMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Mono.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isGateEnabled("some-feature")).thenReturn(Mono.just(true));
+    Schedule inactiveSchedule = new Schedule(null, LocalDateTime.of(2020, 1, 1, 0, 0), null);
+    when(reactiveScheduleProvider.getSchedule("some-feature"))
+        .thenReturn(Mono.just(inactiveSchedule));
+
+    ServerWebExchange exchange = mockExchange();
+    Object result = aspect.checkEndpointGate(joinPoint);
+
+    StepVerifier.create(
+            ((Mono<Object>) result).contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectError(EndpointGateAccessDeniedException.class)
+        .verify();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void checkEndpointGate_proceeds_whenScheduleIsActive_forMono() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("monoMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Mono.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isGateEnabled("some-feature")).thenReturn(Mono.just(true));
+    Schedule activeSchedule = new Schedule(LocalDateTime.of(2020, 1, 1, 0, 0), null, null);
+    when(reactiveScheduleProvider.getSchedule("some-feature"))
+        .thenReturn(Mono.just(activeSchedule));
+    when(joinPoint.proceed()).thenReturn(Mono.just("result"));
+
+    ServerWebExchange exchange = mockExchange();
+    Object result = aspect.checkEndpointGate(joinPoint);
+
+    StepVerifier.create(
+            ((Mono<Object>) result).contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectNext("result")
+        .verifyComplete();
+  }
+
+  // --- checkSchedule for Flux ---
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void checkEndpointGate_emitsError_whenScheduleIsInactive_forFlux() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("fluxMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Flux.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isGateEnabled("some-feature")).thenReturn(Mono.just(true));
+    Schedule inactiveSchedule = new Schedule(null, LocalDateTime.of(2020, 1, 1, 0, 0), null);
+    when(reactiveScheduleProvider.getSchedule("some-feature"))
+        .thenReturn(Mono.just(inactiveSchedule));
+
+    ServerWebExchange exchange = mockExchange();
+    Object result = aspect.checkEndpointGate(joinPoint);
+
+    StepVerifier.create(
+            ((Flux<Object>) result).contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectError(EndpointGateAccessDeniedException.class)
+        .verify();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void checkEndpointGate_proceeds_whenScheduleIsActive_forFlux() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("fluxMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Flux.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isGateEnabled("some-feature")).thenReturn(Mono.just(true));
+    Schedule activeSchedule = new Schedule(LocalDateTime.of(2020, 1, 1, 0, 0), null, null);
+    when(reactiveScheduleProvider.getSchedule("some-feature"))
+        .thenReturn(Mono.just(activeSchedule));
+    when(joinPoint.proceed()).thenReturn(Flux.just("r1", "r2"));
+
+    ServerWebExchange exchange = mockExchange();
+    Object result = aspect.checkEndpointGate(joinPoint);
+
+    StepVerifier.create(
+            ((Flux<Object>) result).contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectNext("r1", "r2")
+        .verifyComplete();
+  }
+
+  @Test
+  void checkEndpointGate_throwsIllegalStateException_whenAnnotationValueIsEmpty() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("emptyAnnotationMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+
+    assertThatThrownBy(() -> aspect.checkEndpointGate(joinPoint))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("non-empty value");
+  }
+
+  @Test
+  void checkEndpointGate_throwsIllegalStateException_whenReturnTypeIsNonReactive()
+      throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("nonReactiveMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(String.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+
+    assertThatThrownBy(() -> aspect.checkEndpointGate(joinPoint))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("reactive return type");
+  }
+
+  @Test
+  void checkEndpointGate_proceedsWithoutCheck_whenNoAnnotationFound() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = NoAnnotationController.class.getMethod("noAnnotationMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(joinPoint.getTarget()).thenReturn(new NoAnnotationController());
+    when(joinPoint.proceed()).thenReturn(Mono.just("result"));
+
+    aspect.checkEndpointGate(joinPoint);
+
+    verify(joinPoint).proceed();
+    verifyNoInteractions(provider);
+  }
+
+  @Test
+  void checkEndpointGate_returnsMono_whenGateEnabled() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("monoMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Mono.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isGateEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(joinPoint.proceed()).thenReturn(Mono.just("result"));
+
+    ServerWebExchange exchange = mockExchange();
+    Object result = aspect.checkEndpointGate(joinPoint);
+
+    @SuppressWarnings("unchecked")
+    Mono<String> mono = (Mono<String>) result;
+    StepVerifier.create(mono.contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectNext("result")
+        .verifyComplete();
+  }
+
+  @Test
+  void checkEndpointGate_returnsMonoError_whenGateDisabled() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("monoMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Mono.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isGateEnabled("some-feature")).thenReturn(Mono.just(false));
+
+    ServerWebExchange exchange = mockExchange();
+    Object result = aspect.checkEndpointGate(joinPoint);
+
+    StepVerifier.create(
+            ((Mono<?>) result).contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectErrorMatches(
+            e ->
+                e instanceof EndpointGateAccessDeniedException
+                    && ((EndpointGateAccessDeniedException) e).gateId().equals("some-feature"))
+        .verify();
+  }
+
+  @Test
+  void checkEndpointGate_returnsMonoError_whenRolloutCheckFails() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("rolloutMonoMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Mono.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isGateEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(rolloutPercentageProvider.getRolloutPercentage("some-feature")).thenReturn(Mono.just(50));
+
+    ServerWebExchange exchange = mock(ServerWebExchange.class);
+    ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);
+    when(exchange.getRequest()).thenReturn(httpRequest);
+    stubRequestForConditionVariables(httpRequest);
+
+    EndpointGateContext context = new EndpointGateContext("user-1");
+    when(contextResolver.resolve(httpRequest)).thenReturn(Mono.just(context));
+    when(rolloutStrategy.isInRollout("some-feature", context, 50)).thenReturn(Mono.just(false));
+
+    Object result = aspectWithRollout.checkEndpointGate(joinPoint);
+
+    StepVerifier.create(
+            ((Mono<?>) result).contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectErrorMatches(
+            e ->
+                e instanceof EndpointGateAccessDeniedException
+                    && ((EndpointGateAccessDeniedException) e).gateId().equals("some-feature"))
+        .verify();
+  }
+
+  @Test
+  void checkEndpointGate_returnsMono_whenRolloutCheckPasses() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("rolloutMonoMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Mono.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isGateEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(rolloutPercentageProvider.getRolloutPercentage("some-feature")).thenReturn(Mono.just(50));
+    when(joinPoint.proceed()).thenReturn(Mono.just("result"));
+
+    ServerWebExchange exchange = mock(ServerWebExchange.class);
+    ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);
+    when(exchange.getRequest()).thenReturn(httpRequest);
+    stubRequestForConditionVariables(httpRequest);
+
+    EndpointGateContext context = new EndpointGateContext("user-1");
+    when(contextResolver.resolve(httpRequest)).thenReturn(Mono.just(context));
+    when(rolloutStrategy.isInRollout("some-feature", context, 50)).thenReturn(Mono.just(true));
+
+    Object result = aspectWithRollout.checkEndpointGate(joinPoint);
+
+    @SuppressWarnings("unchecked")
+    Mono<String> mono = (Mono<String>) result;
+    StepVerifier.create(mono.contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectNext("result")
+        .verifyComplete();
+  }
+
+  @Test
+  void checkEndpointGate_returnsMono_whenContextIsEmpty() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("rolloutMonoMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Mono.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isGateEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(rolloutPercentageProvider.getRolloutPercentage("some-feature")).thenReturn(Mono.just(50));
+    when(joinPoint.proceed()).thenReturn(Mono.just("result"));
+
+    ServerWebExchange exchange = mock(ServerWebExchange.class);
+    ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);
+    when(exchange.getRequest()).thenReturn(httpRequest);
+    stubRequestForConditionVariables(httpRequest);
+    when(contextResolver.resolve(httpRequest)).thenReturn(Mono.empty());
+
+    Object result = aspectWithRollout.checkEndpointGate(joinPoint);
+
+    @SuppressWarnings("unchecked")
+    Mono<String> mono = (Mono<String>) result;
+    StepVerifier.create(mono.contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectNext("result")
+        .verifyComplete();
+  }
+
+  @Test
+  void checkEndpointGate_returnsFluxError_whenRolloutCheckFails() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("rolloutFluxMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Flux.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isGateEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(rolloutPercentageProvider.getRolloutPercentage("some-feature")).thenReturn(Mono.just(50));
+
+    ServerWebExchange exchange = mock(ServerWebExchange.class);
+    ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);
+    when(exchange.getRequest()).thenReturn(httpRequest);
+    stubRequestForConditionVariables(httpRequest);
+
+    EndpointGateContext context = new EndpointGateContext("user-1");
+    when(contextResolver.resolve(httpRequest)).thenReturn(Mono.just(context));
+    when(rolloutStrategy.isInRollout("some-feature", context, 50)).thenReturn(Mono.just(false));
+
+    Object result = aspectWithRollout.checkEndpointGate(joinPoint);
+
+    StepVerifier.create(
+            ((Flux<?>) result).contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectErrorMatches(
+            e ->
+                e instanceof EndpointGateAccessDeniedException
+                    && ((EndpointGateAccessDeniedException) e).gateId().equals("some-feature"))
+        .verify();
+  }
+
+  @Test
+  void checkEndpointGate_returnsFlux_whenRolloutCheckPasses() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("rolloutFluxMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Flux.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isGateEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(rolloutPercentageProvider.getRolloutPercentage("some-feature")).thenReturn(Mono.just(50));
+    when(joinPoint.proceed()).thenReturn(Flux.just("result1", "result2"));
+
+    ServerWebExchange exchange = mock(ServerWebExchange.class);
+    ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);
+    when(exchange.getRequest()).thenReturn(httpRequest);
+    stubRequestForConditionVariables(httpRequest);
+
+    EndpointGateContext context = new EndpointGateContext("user-1");
+    when(contextResolver.resolve(httpRequest)).thenReturn(Mono.just(context));
+    when(rolloutStrategy.isInRollout("some-feature", context, 50)).thenReturn(Mono.just(true));
+
+    Object result = aspectWithRollout.checkEndpointGate(joinPoint);
+
+    @SuppressWarnings("unchecked")
+    Flux<String> flux = (Flux<String>) result;
+    StepVerifier.create(flux.contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectNext("result1", "result2")
+        .verifyComplete();
+  }
+
+  @Test
+  void checkEndpointGate_returnsFlux_whenContextIsEmpty() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("rolloutFluxMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Flux.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isGateEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(rolloutPercentageProvider.getRolloutPercentage("some-feature")).thenReturn(Mono.just(50));
+    when(joinPoint.proceed()).thenReturn(Flux.just("result1", "result2"));
+
+    ServerWebExchange exchange = mock(ServerWebExchange.class);
+    ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);
+    when(exchange.getRequest()).thenReturn(httpRequest);
+    stubRequestForConditionVariables(httpRequest);
+    when(contextResolver.resolve(httpRequest)).thenReturn(Mono.empty());
+
+    Object result = aspectWithRollout.checkEndpointGate(joinPoint);
+
+    @SuppressWarnings("unchecked")
+    Flux<String> flux = (Flux<String>) result;
+    StepVerifier.create(flux.contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectNext("result1", "result2")
+        .verifyComplete();
+  }
+
+  @Test
+  void checkEndpointGate_returnsFlux_whenGateEnabled() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("fluxMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Flux.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isGateEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(joinPoint.proceed()).thenReturn(Flux.just("result1", "result2"));
+
+    ServerWebExchange exchange = mockExchange();
+    Object result = aspect.checkEndpointGate(joinPoint);
+
+    @SuppressWarnings("unchecked")
+    Flux<String> flux = (Flux<String>) result;
+    StepVerifier.create(flux.contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectNext("result1", "result2")
+        .verifyComplete();
+  }
+
+  @Test
+  void checkEndpointGate_returnsMonoError_whenProceedThrows() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("monoMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Mono.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isGateEnabled("some-feature")).thenReturn(Mono.just(true));
+    RuntimeException cause = new RuntimeException("unexpected");
+    when(joinPoint.proceed()).thenThrow(cause);
+
+    ServerWebExchange exchange = mockExchange();
+    Object result = aspect.checkEndpointGate(joinPoint);
+
+    StepVerifier.create(
+            ((Mono<?>) result).contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectErrorMatches(e -> e == cause)
+        .verify();
+  }
+
+  @Test
+  void checkEndpointGate_returnsFluxError_whenGateDisabled() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("fluxMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Flux.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isGateEnabled("some-feature")).thenReturn(Mono.just(false));
+
+    ServerWebExchange exchange = mockExchange();
+    Object result = aspect.checkEndpointGate(joinPoint);
+
+    StepVerifier.create(
+            ((Flux<?>) result).contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectErrorMatches(
+            e ->
+                e instanceof EndpointGateAccessDeniedException
+                    && ((EndpointGateAccessDeniedException) e).gateId().equals("some-feature"))
+        .verify();
+  }
+
+  // --- condition ---
+
+  private void stubRequestForConditionVariables(ServerHttpRequest httpRequest) {
+    when(httpRequest.getHeaders()).thenReturn(new HttpHeaders());
+    when(httpRequest.getQueryParams()).thenReturn(new LinkedMultiValueMap<>());
+    when(httpRequest.getCookies()).thenReturn(new LinkedMultiValueMap<>());
+    org.springframework.http.server.RequestPath path =
+        mock(org.springframework.http.server.RequestPath.class);
+    when(path.value()).thenReturn("/test");
+    when(httpRequest.getPath()).thenReturn(path);
+    when(httpRequest.getMethod()).thenReturn(HttpMethod.GET);
+    when(httpRequest.getRemoteAddress()).thenReturn(null);
+  }
+
+  @Test
+  void checkEndpointGate_returnsMono_whenConditionIsTrue() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("conditionMonoMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Mono.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isGateEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(conditionProvider.getCondition("some-feature"))
+        .thenReturn(Mono.just("headers['X-Beta'] != null"));
+    when(joinPoint.proceed()).thenReturn(Mono.just("result"));
+    when(conditionEvaluator.evaluate(
+            org.mockito.ArgumentMatchers.eq("headers['X-Beta'] != null"),
+            org.mockito.ArgumentMatchers.any()))
+        .thenReturn(Mono.just(true));
+
+    ServerWebExchange exchange = mock(ServerWebExchange.class);
+    ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);
+    when(exchange.getRequest()).thenReturn(httpRequest);
+    stubRequestForConditionVariables(httpRequest);
+
+    Object result = aspect.checkEndpointGate(joinPoint);
+
+    @SuppressWarnings("unchecked")
+    Mono<String> mono = (Mono<String>) result;
+    StepVerifier.create(mono.contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectNext("result")
+        .verifyComplete();
+  }
+
+  @Test
+  void checkEndpointGate_returnsMonoError_whenConditionIsFalse() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("conditionMonoMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Mono.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isGateEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(conditionProvider.getCondition("some-feature"))
+        .thenReturn(Mono.just("headers['X-Beta'] != null"));
+    when(conditionEvaluator.evaluate(
+            org.mockito.ArgumentMatchers.eq("headers['X-Beta'] != null"),
+            org.mockito.ArgumentMatchers.any()))
+        .thenReturn(Mono.just(false));
+
+    ServerWebExchange exchange = mock(ServerWebExchange.class);
+    ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);
+    when(exchange.getRequest()).thenReturn(httpRequest);
+    stubRequestForConditionVariables(httpRequest);
+
+    Object result = aspect.checkEndpointGate(joinPoint);
+
+    StepVerifier.create(
+            ((Mono<?>) result).contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectErrorMatches(
+            e ->
+                e instanceof EndpointGateAccessDeniedException
+                    && ((EndpointGateAccessDeniedException) e).gateId().equals("some-feature"))
+        .verify();
+  }
+
+  @Test
+  void checkEndpointGate_returnsFlux_whenConditionIsTrue() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("conditionFluxMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Flux.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isGateEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(conditionProvider.getCondition("some-feature"))
+        .thenReturn(Mono.just("headers['X-Beta'] != null"));
+    when(joinPoint.proceed()).thenReturn(Flux.just("result1", "result2"));
+    when(conditionEvaluator.evaluate(
+            org.mockito.ArgumentMatchers.eq("headers['X-Beta'] != null"),
+            org.mockito.ArgumentMatchers.any()))
+        .thenReturn(Mono.just(true));
+
+    ServerWebExchange exchange = mock(ServerWebExchange.class);
+    ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);
+    when(exchange.getRequest()).thenReturn(httpRequest);
+    stubRequestForConditionVariables(httpRequest);
+
+    Object result = aspect.checkEndpointGate(joinPoint);
+
+    @SuppressWarnings("unchecked")
+    Flux<String> flux = (Flux<String>) result;
+    StepVerifier.create(flux.contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectNext("result1", "result2")
+        .verifyComplete();
+  }
+
+  @Test
+  void checkEndpointGate_returnsFluxError_whenConditionIsFalse() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("conditionFluxMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Flux.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isGateEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(conditionProvider.getCondition("some-feature"))
+        .thenReturn(Mono.just("headers['X-Beta'] != null"));
+    when(conditionEvaluator.evaluate(
+            org.mockito.ArgumentMatchers.eq("headers['X-Beta'] != null"),
+            org.mockito.ArgumentMatchers.any()))
+        .thenReturn(Mono.just(false));
+
+    ServerWebExchange exchange = mock(ServerWebExchange.class);
+    ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);
+    when(exchange.getRequest()).thenReturn(httpRequest);
+    stubRequestForConditionVariables(httpRequest);
+
+    Object result = aspect.checkEndpointGate(joinPoint);
+
+    StepVerifier.create(
+            ((Flux<?>) result).contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectErrorMatches(
+            e ->
+                e instanceof EndpointGateAccessDeniedException
+                    && ((EndpointGateAccessDeniedException) e).gateId().equals("some-feature"))
+        .verify();
+  }
+
+  @Test
+  void checkEndpointGate_skipsConditionCheck_whenConditionIsEmpty() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("monoMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Mono.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isGateEnabled("some-feature")).thenReturn(Mono.just(true));
+    when(joinPoint.proceed()).thenReturn(Mono.just("result"));
+
+    ServerWebExchange exchange = mockExchange();
+    Object result = aspect.checkEndpointGate(joinPoint);
+
+    @SuppressWarnings("unchecked")
+    Mono<Object> mono = (Mono<Object>) result;
+    StepVerifier.create(mono.contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectNextCount(1)
+        .verifyComplete();
+    verifyNoInteractions(conditionEvaluator);
+  }
+
+  @Test
+  void checkEndpointGate_returnsFluxError_whenProceedThrows() throws Throwable {
+    ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+    MethodSignature signature = mock(MethodSignature.class);
+    when(joinPoint.getSignature()).thenReturn(signature);
+
+    Method method = TestController.class.getMethod("fluxMethod");
+    when(signature.getMethod()).thenReturn(method);
+    when(signature.getReturnType()).thenReturn(Flux.class);
+    when(joinPoint.getTarget()).thenReturn(new TestController());
+    when(provider.isGateEnabled("some-feature")).thenReturn(Mono.just(true));
+    RuntimeException cause = new RuntimeException("unexpected");
+    when(joinPoint.proceed()).thenThrow(cause);
+
+    ServerWebExchange exchange = mockExchange();
+    Object result = aspect.checkEndpointGate(joinPoint);
+
+    StepVerifier.create(
+            ((Flux<?>) result).contextWrite(ctx -> ctx.put(ServerWebExchange.class, exchange)))
+        .expectErrorMatches(e -> e == cause)
+        .verify();
+  }
+}

--- a/spring/webflux/src/test/java/net/brightroom/endpointgate/spring/webflux/context/RandomReactiveEndpointGateContextResolverTest.java
+++ b/spring/webflux/src/test/java/net/brightroom/endpointgate/spring/webflux/context/RandomReactiveEndpointGateContextResolverTest.java
@@ -1,0 +1,39 @@
+package net.brightroom.endpointgate.spring.webflux.context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import net.brightroom.endpointgate.core.context.EndpointGateContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import reactor.test.StepVerifier;
+
+class RandomReactiveEndpointGateContextResolverTest {
+
+  private final RandomReactiveEndpointGateContextResolver resolver =
+      new RandomReactiveEndpointGateContextResolver();
+  private final ServerHttpRequest request = mock(ServerHttpRequest.class);
+
+  @Test
+  void resolve_returnsNonEmptyContext() {
+    StepVerifier.create(resolver.resolve(request))
+        .assertNext(ctx -> assertThat(ctx).isNotNull())
+        .verifyComplete();
+  }
+
+  @Test
+  void resolve_returnsContextWithNonBlankIdentifier() {
+    StepVerifier.create(resolver.resolve(request))
+        .assertNext(ctx -> assertThat(ctx.userIdentifier()).isNotBlank())
+        .verifyComplete();
+  }
+
+  @Test
+  void resolve_returnsDifferentContextPerRequest() {
+    EndpointGateContext first = resolver.resolve(request).block();
+    EndpointGateContext second = resolver.resolve(request).block();
+    assertThat(first).isNotNull();
+    assertThat(second).isNotNull();
+    assertThat(first.userIdentifier()).isNotEqualTo(second.userIdentifier());
+  }
+}

--- a/spring/webflux/src/test/java/net/brightroom/endpointgate/spring/webflux/filter/EndpointGateHandlerFilterFunctionTest.java
+++ b/spring/webflux/src/test/java/net/brightroom/endpointgate/spring/webflux/filter/EndpointGateHandlerFilterFunctionTest.java
@@ -1,0 +1,379 @@
+package net.brightroom.endpointgate.spring.webflux.filter;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import net.brightroom.endpointgate.core.context.EndpointGateContext;
+import net.brightroom.endpointgate.core.exception.EndpointGateAccessDeniedException;
+import net.brightroom.endpointgate.core.provider.Schedule;
+import net.brightroom.endpointgate.reactive.core.condition.ReactiveEndpointGateConditionEvaluator;
+import net.brightroom.endpointgate.reactive.core.evaluation.ReactiveConditionEvaluationStep;
+import net.brightroom.endpointgate.reactive.core.evaluation.ReactiveEnabledEvaluationStep;
+import net.brightroom.endpointgate.reactive.core.evaluation.ReactiveEndpointGateEvaluationPipeline;
+import net.brightroom.endpointgate.reactive.core.evaluation.ReactiveRolloutEvaluationStep;
+import net.brightroom.endpointgate.reactive.core.evaluation.ReactiveScheduleEvaluationStep;
+import net.brightroom.endpointgate.reactive.core.provider.ReactiveConditionProvider;
+import net.brightroom.endpointgate.reactive.core.provider.ReactiveEndpointGateProvider;
+import net.brightroom.endpointgate.reactive.core.provider.ReactiveRolloutPercentageProvider;
+import net.brightroom.endpointgate.reactive.core.provider.ReactiveScheduleProvider;
+import net.brightroom.endpointgate.reactive.core.rollout.DefaultReactiveRolloutStrategy;
+import net.brightroom.endpointgate.reactive.core.rollout.ReactiveRolloutStrategy;
+import net.brightroom.endpointgate.spring.webflux.context.ReactiveEndpointGateContextResolver;
+import net.brightroom.endpointgate.spring.webflux.resolution.handlerfilter.AccessDeniedHandlerFilterResolution;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.reactive.function.server.HandlerFilterFunction;
+import org.springframework.web.reactive.function.server.HandlerFunction;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class EndpointGateHandlerFilterFunctionTest {
+
+  private final ReactiveEndpointGateProvider provider = mock(ReactiveEndpointGateProvider.class);
+  private final AccessDeniedHandlerFilterResolution resolution =
+      mock(AccessDeniedHandlerFilterResolution.class);
+  private final ReactiveEndpointGateContextResolver contextResolver =
+      mock(ReactiveEndpointGateContextResolver.class, invocation -> Mono.empty());
+  private final ReactiveRolloutPercentageProvider rolloutPercentageProvider =
+      mock(ReactiveRolloutPercentageProvider.class, invocation -> Mono.empty());
+  private final ReactiveConditionProvider conditionProvider =
+      mock(ReactiveConditionProvider.class, invocation -> Mono.empty());
+  private final ReactiveEndpointGateConditionEvaluator conditionEvaluator =
+      mock(ReactiveEndpointGateConditionEvaluator.class);
+  private final ReactiveScheduleProvider reactiveScheduleProvider =
+      mock(ReactiveScheduleProvider.class, invocation -> Mono.empty());
+  private final ReactiveRolloutStrategy rolloutStrategy = mock(ReactiveRolloutStrategy.class);
+
+  private ReactiveEndpointGateEvaluationPipeline buildPipeline(ReactiveRolloutStrategy strategy) {
+    return new ReactiveEndpointGateEvaluationPipeline(
+        new ReactiveEnabledEvaluationStep(provider),
+        new ReactiveScheduleEvaluationStep(reactiveScheduleProvider, Clock.systemDefaultZone()),
+        new ReactiveConditionEvaluationStep(conditionEvaluator),
+        new ReactiveRolloutEvaluationStep(strategy));
+  }
+
+  private final EndpointGateHandlerFilterFunction filterFunction =
+      new EndpointGateHandlerFilterFunction(
+          buildPipeline(new DefaultReactiveRolloutStrategy()),
+          resolution,
+          rolloutPercentageProvider,
+          conditionProvider,
+          contextResolver);
+
+  private final EndpointGateHandlerFilterFunction filterFunctionWithRollout =
+      new EndpointGateHandlerFilterFunction(
+          buildPipeline(rolloutStrategy),
+          resolution,
+          rolloutPercentageProvider,
+          conditionProvider,
+          contextResolver);
+
+  private ServerRequest mockRequest() {
+    ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);
+    when(httpRequest.getHeaders()).thenReturn(new HttpHeaders());
+    when(httpRequest.getQueryParams()).thenReturn(new LinkedMultiValueMap<>());
+    when(httpRequest.getCookies()).thenReturn(new LinkedMultiValueMap<>());
+    org.springframework.http.server.RequestPath path =
+        mock(org.springframework.http.server.RequestPath.class);
+    when(path.value()).thenReturn("/test");
+    when(httpRequest.getPath()).thenReturn(path);
+    when(httpRequest.getMethod()).thenReturn(HttpMethod.GET);
+    when(httpRequest.getRemoteAddress()).thenReturn(null);
+    ServerWebExchange exchange = mock(ServerWebExchange.class);
+    when(exchange.getRequest()).thenReturn(httpRequest);
+    ServerRequest request = mock(ServerRequest.class);
+    when(request.exchange()).thenReturn(exchange);
+    return request;
+  }
+
+  private ServerRequest mockRequest(ServerHttpRequest httpRequest) {
+    ServerWebExchange exchange = mock(ServerWebExchange.class);
+    when(exchange.getRequest()).thenReturn(httpRequest);
+    ServerRequest request = mock(ServerRequest.class);
+    when(request.exchange()).thenReturn(exchange);
+    return request;
+  }
+
+  private ServerHttpRequest mockHttpRequest() {
+    ServerHttpRequest httpRequest = mock(ServerHttpRequest.class);
+    when(httpRequest.getHeaders()).thenReturn(new HttpHeaders());
+    when(httpRequest.getQueryParams()).thenReturn(new LinkedMultiValueMap<>());
+    when(httpRequest.getCookies()).thenReturn(new LinkedMultiValueMap<>());
+    org.springframework.http.server.RequestPath path =
+        mock(org.springframework.http.server.RequestPath.class);
+    when(path.value()).thenReturn("/functional/condition/header");
+    when(httpRequest.getPath()).thenReturn(path);
+    when(httpRequest.getMethod()).thenReturn(HttpMethod.GET);
+    when(httpRequest.getRemoteAddress()).thenReturn(null);
+    return httpRequest;
+  }
+
+  // --- validation ---
+
+  @Test
+  void of_throwsIllegalArgumentException_whenGateIdIsNull() {
+    assertThatThrownBy(() -> filterFunction.of(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("null or blank");
+  }
+
+  @Test
+  void of_throwsIllegalArgumentException_whenGateIdIsEmpty() {
+    assertThatThrownBy(() -> filterFunction.of(""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("null or blank");
+  }
+
+  @Test
+  void of_throwsIllegalArgumentException_whenRolloutIsNegative() {
+    assertThatThrownBy(() -> filterFunction.of("my-gate", -1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("rollout must be between 0 and 100");
+  }
+
+  @Test
+  void of_throwsIllegalArgumentException_whenRolloutIsOver100() {
+    assertThatThrownBy(() -> filterFunction.of("my-gate", 101))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("rollout must be between 0 and 100");
+  }
+
+  // --- enabled check ---
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_delegatesToNext_whenGateEnabled() {
+    when(provider.isGateEnabled("my-gate")).thenReturn(Mono.just(true));
+    ServerRequest request = mockRequest();
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse okResponse = mock(ServerResponse.class);
+    when(next.handle(request)).thenReturn(Mono.just(okResponse));
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter = filterFunction.of("my-gate");
+    StepVerifier.create(filter.filter(request, next)).expectNext(okResponse).verifyComplete();
+
+    verify(next).handle(request);
+    verifyNoInteractions(resolution);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_delegatesToResolution_whenGateDisabled() {
+    when(provider.isGateEnabled("my-gate")).thenReturn(Mono.just(false));
+    ServerRequest request = mockRequest();
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse deniedResponse = mock(ServerResponse.class);
+    when(resolution.resolve(eq(request), any(EndpointGateAccessDeniedException.class)))
+        .thenReturn(Mono.just(deniedResponse));
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter = filterFunction.of("my-gate");
+    StepVerifier.create(filter.filter(request, next)).expectNext(deniedResponse).verifyComplete();
+
+    verifyNoInteractions(next);
+    verify(resolution).resolve(eq(request), any(EndpointGateAccessDeniedException.class));
+  }
+
+  // --- schedule check ---
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_delegatesToResolution_whenScheduleIsInactive() {
+    when(provider.isGateEnabled("my-gate")).thenReturn(Mono.just(true));
+    Schedule inactiveSchedule = new Schedule(null, LocalDateTime.of(2020, 1, 1, 0, 0), null);
+    when(reactiveScheduleProvider.getSchedule("my-gate")).thenReturn(Mono.just(inactiveSchedule));
+
+    ServerRequest request = mockRequest();
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse deniedResponse = mock(ServerResponse.class);
+    when(resolution.resolve(eq(request), any(EndpointGateAccessDeniedException.class)))
+        .thenReturn(Mono.just(deniedResponse));
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter = filterFunction.of("my-gate");
+    StepVerifier.create(filter.filter(request, next)).expectNext(deniedResponse).verifyComplete();
+
+    verifyNoInteractions(next);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_delegatesToNext_whenScheduleIsActive() {
+    when(provider.isGateEnabled("my-gate")).thenReturn(Mono.just(true));
+    Schedule activeSchedule = new Schedule(LocalDateTime.of(2020, 1, 1, 0, 0), null, null);
+    when(reactiveScheduleProvider.getSchedule("my-gate")).thenReturn(Mono.just(activeSchedule));
+
+    ServerRequest request = mockRequest();
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse okResponse = mock(ServerResponse.class);
+    when(next.handle(request)).thenReturn(Mono.just(okResponse));
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter = filterFunction.of("my-gate");
+    StepVerifier.create(filter.filter(request, next)).expectNext(okResponse).verifyComplete();
+
+    verify(next).handle(request);
+    verifyNoInteractions(resolution);
+  }
+
+  // --- condition check ---
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_skipsConditionCheck_whenConditionIsEmpty() {
+    when(provider.isGateEnabled("my-gate")).thenReturn(Mono.just(true));
+    ServerRequest request = mockRequest();
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse okResponse = mock(ServerResponse.class);
+    when(next.handle(request)).thenReturn(Mono.just(okResponse));
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter = filterFunction.of("my-gate");
+    StepVerifier.create(filter.filter(request, next)).expectNext(okResponse).verifyComplete();
+
+    verifyNoInteractions(conditionEvaluator);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_delegatesToNext_whenConditionPasses() {
+    when(provider.isGateEnabled("my-gate")).thenReturn(Mono.just(true));
+    ServerHttpRequest httpRequest = mockHttpRequest();
+    ServerRequest request = mockRequest(httpRequest);
+
+    when(conditionEvaluator.evaluate(eq("headers['X-Beta'] != null"), any()))
+        .thenReturn(Mono.just(true));
+
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse okResponse = mock(ServerResponse.class);
+    when(next.handle(request)).thenReturn(Mono.just(okResponse));
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter =
+        filterFunction.of("my-gate", "headers['X-Beta'] != null");
+    StepVerifier.create(filter.filter(request, next)).expectNext(okResponse).verifyComplete();
+
+    verify(next).handle(request);
+    verifyNoInteractions(resolution);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_delegatesToResolution_whenConditionFails() {
+    when(provider.isGateEnabled("my-gate")).thenReturn(Mono.just(true));
+    ServerHttpRequest httpRequest = mockHttpRequest();
+    ServerRequest request = mockRequest(httpRequest);
+
+    when(conditionEvaluator.evaluate(eq("headers['X-Beta'] != null"), any()))
+        .thenReturn(Mono.just(false));
+
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse deniedResponse = mock(ServerResponse.class);
+    when(resolution.resolve(eq(request), any(EndpointGateAccessDeniedException.class)))
+        .thenReturn(Mono.just(deniedResponse));
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter =
+        filterFunction.of("my-gate", "headers['X-Beta'] != null");
+    StepVerifier.create(filter.filter(request, next)).expectNext(deniedResponse).verifyComplete();
+
+    verifyNoInteractions(next);
+    verify(resolution).resolve(eq(request), any(EndpointGateAccessDeniedException.class));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_evaluatesConditionBeforeRollout() {
+    when(provider.isGateEnabled("my-gate")).thenReturn(Mono.just(true));
+    ServerHttpRequest httpRequest = mockHttpRequest();
+    ServerRequest request = mockRequest(httpRequest);
+
+    when(conditionEvaluator.evaluate(eq("headers['X-Beta'] != null"), any()))
+        .thenReturn(Mono.just(false));
+
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse deniedResponse = mock(ServerResponse.class);
+    when(resolution.resolve(eq(request), any(EndpointGateAccessDeniedException.class)))
+        .thenReturn(Mono.just(deniedResponse));
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter =
+        filterFunctionWithRollout.of("my-gate", "headers['X-Beta'] != null", 50);
+    StepVerifier.create(filter.filter(request, next)).expectNext(deniedResponse).verifyComplete();
+
+    verifyNoInteractions(rolloutStrategy);
+  }
+
+  // --- rollout check ---
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_delegatesToNext_whenRolloutCheckPasses() {
+    when(provider.isGateEnabled("my-gate")).thenReturn(Mono.just(true));
+    ServerHttpRequest httpRequest = mockHttpRequest();
+    EndpointGateContext context = new EndpointGateContext("u1");
+    when(contextResolver.resolve(httpRequest)).thenReturn(Mono.just(context));
+    ServerRequest request = mockRequest(httpRequest);
+
+    when(rolloutStrategy.isInRollout("my-gate", context, 50)).thenReturn(Mono.just(true));
+
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse okResponse = mock(ServerResponse.class);
+    when(next.handle(request)).thenReturn(Mono.just(okResponse));
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter =
+        filterFunctionWithRollout.of("my-gate", 50);
+    StepVerifier.create(filter.filter(request, next)).expectNext(okResponse).verifyComplete();
+
+    verify(next).handle(request);
+    verifyNoInteractions(resolution);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_delegatesToResolution_whenRolloutCheckFails() {
+    when(provider.isGateEnabled("my-gate")).thenReturn(Mono.just(true));
+    ServerHttpRequest httpRequest = mockHttpRequest();
+    EndpointGateContext context = new EndpointGateContext("u1");
+    when(contextResolver.resolve(httpRequest)).thenReturn(Mono.just(context));
+    ServerRequest request = mockRequest(httpRequest);
+
+    when(rolloutStrategy.isInRollout("my-gate", context, 50)).thenReturn(Mono.just(false));
+
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse deniedResponse = mock(ServerResponse.class);
+    when(resolution.resolve(eq(request), any(EndpointGateAccessDeniedException.class)))
+        .thenReturn(Mono.just(deniedResponse));
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter =
+        filterFunctionWithRollout.of("my-gate", 50);
+    StepVerifier.create(filter.filter(request, next)).expectNext(deniedResponse).verifyComplete();
+
+    verifyNoInteractions(next);
+    verify(resolution).resolve(eq(request), any(EndpointGateAccessDeniedException.class));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void of_delegatesToNext_whenContextIsEmpty() {
+    when(provider.isGateEnabled("my-gate")).thenReturn(Mono.just(true));
+    ServerRequest request = mockRequest();
+
+    HandlerFunction<ServerResponse> next = mock(HandlerFunction.class);
+    ServerResponse okResponse = mock(ServerResponse.class);
+    when(next.handle(request)).thenReturn(Mono.just(okResponse));
+
+    HandlerFilterFunction<ServerResponse, ServerResponse> filter =
+        filterFunctionWithRollout.of("my-gate", 50);
+    StepVerifier.create(filter.filter(request, next)).expectNext(okResponse).verifyComplete();
+
+    verify(next).handle(request);
+    verifyNoInteractions(resolution);
+  }
+}

--- a/spring/webflux/src/test/resources/application.yaml
+++ b/spring/webflux/src/test/resources/application.yaml
@@ -1,0 +1,8 @@
+endpoint-gate:
+  gates:
+    experimental-stage-endpoint:
+      enabled: true
+    development-stage-endpoint:
+      enabled: false
+  response:
+    type: json


### PR DESCRIPTION
## Summary

- Port the `webflux` module from `feature-flag-spring-boot-starter` to `endpoint-gate` as `spring-webflux`
- Rename all classes from `FeatureFlag*` to `EndpointGate*` and remove deprecated `InMemoryReactiveFeatureFlagProvider` alias
- Depend on `spring-core` + `reactive-core` as specified in the issue

## Changes

### Main sources (`net.brightroom.endpointgate.spring.webflux`)
- `EndpointGateAspect` — AOP aspect for `@EndpointGate` annotated WebFlux controllers (Mono/Flux)
- `EndpointGateHandlerFilterFunction` — filter factory for functional (router-based) endpoints
- `EndpointGateExceptionHandler` — `@ControllerAdvice` at `LOWEST_PRECEDENCE`
- `EndpointGateWebFluxAutoConfiguration` — reactive auto-configuration wiring all beans
- `ReactiveEndpointGateContextResolver` / `RandomReactiveEndpointGateContextResolver` — rollout context SPI
- `ServerHttpConditionVariables` — shared utility for building condition variables from reactive requests
- Resolution classes for exception handler and handler filter (JSON / HTML / plain-text, 6 total)
- `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`

### Tests
- Unit tests: `EndpointGateAspectTest`, `EndpointGateHandlerFilterFunctionTest`, `RandomReactiveEndpointGateContextResolverTest`
- Integration tests: JSON/HTML/plain-text response, fail-closed/fail-open, condition, rollout, custom exception handler, custom handler filter resolution, Netty real-server test

## Test plan
- [x] `./gradlew :spring:spring-webflux:check` passes (Spotless + unit tests + integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)