### PR TITLE
fix(publish): filter subprojects by java plugin before depending on javadocJar

### DIFF
--- a/gradle-scripts/src/main/kotlin/publish-plugin.gradle.kts
+++ b/gradle-scripts/src/main/kotlin/publish-plugin.gradle.kts
@@ -70,7 +70,9 @@ tasks {
         // preventing partial uploads when a sibling module's javadoc fails.
         rootProject.subprojects.forEach { sub ->
             if (sub != project) {
-                dependsOn("${sub.path}:javadocJar")
+                sub.plugins.withId("java") {
+                    dependsOn("${sub.path}:javadocJar")
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- `sonatypeCentralUpload` タスクが全サブプロジェクトの `javadocJar` に依存していたが、`:spring` のような中間プロジェクトには `java` プラグインが適用されておらず `javadocJar` タスクが存在しないためビルドが失敗していた
- `sub.plugins.withId("java")` でフィルタし、`java` プラグインが適用されたサブプロジェクトのみに依存するよう修正

## Test plan
- [x] `./gradlew :core:sonatypeCentralUpload --dry-run` が成功することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)