### PR TITLE
fix(core): add missing Javadoc tags to suppress warnings

### DIFF
--- a/core/src/main/java/net/brightroom/endpointgate/core/condition/ConditionVariables.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/condition/ConditionVariables.java
@@ -48,32 +48,56 @@ public final class ConditionVariables {
     this.remoteAddress = remoteAddress;
   }
 
-  /** Returns the request headers as a case-insensitive map. */
+  /**
+   * Returns the request headers as a case-insensitive map.
+   *
+   * @return unmodifiable map of header names to values
+   */
   public Map<String, String> headers() {
     return headers;
   }
 
-  /** Returns the query parameters. */
+  /**
+   * Returns the query parameters.
+   *
+   * @return unmodifiable map of parameter names to values
+   */
   public Map<String, String> params() {
     return params;
   }
 
-  /** Returns the cookies. */
+  /**
+   * Returns the cookies.
+   *
+   * @return unmodifiable map of cookie names to values
+   */
   public Map<String, String> cookies() {
     return cookies;
   }
 
-  /** Returns the request path. */
+  /**
+   * Returns the request path.
+   *
+   * @return the request path
+   */
   public String path() {
     return path;
   }
 
-  /** Returns the HTTP method. */
+  /**
+   * Returns the HTTP method.
+   *
+   * @return the HTTP method
+   */
   public String method() {
     return method;
   }
 
-  /** Returns the client IP address. */
+  /**
+   * Returns the client IP address.
+   *
+   * @return the client IP address
+   */
   public String remoteAddress() {
     return remoteAddress;
   }

--- a/core/src/main/java/net/brightroom/endpointgate/core/condition/ConditionVariablesBuilder.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/condition/ConditionVariablesBuilder.java
@@ -23,6 +23,9 @@ import java.util.Map;
  */
 public final class ConditionVariablesBuilder {
 
+  /** Creates a new builder with default (empty) values. */
+  public ConditionVariablesBuilder() {}
+
   private Map<String, String> headers = Map.of();
   private Map<String, String> params = Map.of();
   private Map<String, String> cookies = Map.of();
@@ -30,43 +33,77 @@ public final class ConditionVariablesBuilder {
   private String method = "";
   private String remoteAddress = "";
 
-  /** Sets the {@code headers} variable. */
+  /**
+   * Sets the {@code headers} variable.
+   *
+   * @param headers the request headers
+   * @return this builder
+   */
   public ConditionVariablesBuilder headers(Map<String, String> headers) {
     this.headers = headers;
     return this;
   }
 
-  /** Sets the {@code params} variable. */
+  /**
+   * Sets the {@code params} variable.
+   *
+   * @param params the query parameters
+   * @return this builder
+   */
   public ConditionVariablesBuilder params(Map<String, String> params) {
     this.params = params;
     return this;
   }
 
-  /** Sets the {@code cookies} variable. */
+  /**
+   * Sets the {@code cookies} variable.
+   *
+   * @param cookies the cookies
+   * @return this builder
+   */
   public ConditionVariablesBuilder cookies(Map<String, String> cookies) {
     this.cookies = cookies;
     return this;
   }
 
-  /** Sets the {@code path} variable. */
+  /**
+   * Sets the {@code path} variable.
+   *
+   * @param path the request path
+   * @return this builder
+   */
   public ConditionVariablesBuilder path(String path) {
     this.path = path;
     return this;
   }
 
-  /** Sets the {@code method} variable. */
+  /**
+   * Sets the {@code method} variable.
+   *
+   * @param method the HTTP method
+   * @return this builder
+   */
   public ConditionVariablesBuilder method(String method) {
     this.method = method;
     return this;
   }
 
-  /** Sets the {@code remoteAddress} variable. */
+  /**
+   * Sets the {@code remoteAddress} variable.
+   *
+   * @param remoteAddress the client IP address
+   * @return this builder
+   */
   public ConditionVariablesBuilder remoteAddress(String remoteAddress) {
     this.remoteAddress = remoteAddress;
     return this;
   }
 
-  /** Returns the built {@link ConditionVariables}. */
+  /**
+   * Returns the built {@link ConditionVariables}.
+   *
+   * @return a new {@code ConditionVariables} instance
+   */
   public ConditionVariables build() {
     return new ConditionVariables(headers, params, cookies, path, method, remoteAddress);
   }

--- a/core/src/main/java/net/brightroom/endpointgate/core/evaluation/AccessDecision.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/evaluation/AccessDecision.java
@@ -10,7 +10,12 @@ public sealed interface AccessDecision {
   /** Indicates that access is allowed. */
   record Allowed() implements AccessDecision {}
 
-  /** Indicates that access is denied, with the gate identifier and reason. */
+  /**
+   * Indicates that access is denied, with the gate identifier and reason.
+   *
+   * @param gateId the gate identifier that was denied
+   * @param reason the reason for denial
+   */
   record Denied(String gateId, DeniedReason reason) implements AccessDecision {}
 
   /** Reason for denying access in the evaluation pipeline. */

--- a/core/src/main/java/net/brightroom/endpointgate/core/provider/Schedule.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/provider/Schedule.java
@@ -35,6 +35,7 @@ import org.jspecify.annotations.Nullable;
 public record Schedule(
     @Nullable LocalDateTime start, @Nullable LocalDateTime end, @Nullable ZoneId timezone) {
 
+  /** Validates that start is not after end. */
   public Schedule {
     if (start != null && end != null && start.isAfter(end)) {
       throw new IllegalArgumentException(


### PR DESCRIPTION
## Summary
- `core` モジュールの Javadoc 警告（`@param`/`@return` 欠落、コンストラクタコメント欠落）を修正
- 対象: `AccessDecision.Denied`, `ConditionVariables`, `ConditionVariablesBuilder`, `Schedule`

## Test plan
- [x] `./gradlew :core:javadoc` が警告なしで成功することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)