### PR TITLE
fix: resolve all review findings from REVIEW-main.md

### DIFF
--- a/core/src/main/java/net/brightroom/endpointgate/core/provider/InMemoryRolloutPercentageProvider.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/provider/InMemoryRolloutPercentageProvider.java
@@ -15,7 +15,10 @@ public class InMemoryRolloutPercentageProvider implements RolloutPercentageProvi
   @Override
   public OptionalInt getRolloutPercentage(String gateId) {
     Integer percentage = rolloutPercentages.get(gateId);
-    return percentage != null ? OptionalInt.of(percentage) : OptionalInt.empty();
+    if (percentage != null) {
+      return OptionalInt.of(percentage);
+    }
+    return OptionalInt.empty();
   }
 
   /**

--- a/core/src/main/java/net/brightroom/endpointgate/core/provider/MutableInMemoryRolloutPercentageProvider.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/provider/MutableInMemoryRolloutPercentageProvider.java
@@ -18,7 +18,10 @@ public class MutableInMemoryRolloutPercentageProvider implements MutableRolloutP
   @Override
   public OptionalInt getRolloutPercentage(String gateId) {
     Integer percentage = rolloutPercentages.get(gateId);
-    return percentage != null ? OptionalInt.of(percentage) : OptionalInt.empty();
+    if (percentage != null) {
+      return OptionalInt.of(percentage);
+    }
+    return OptionalInt.empty();
   }
 
   /** {@inheritDoc} */

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveRolloutEvaluationStep.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/evaluation/ReactiveRolloutEvaluationStep.java
@@ -33,9 +33,11 @@ public class ReactiveRolloutEvaluationStep implements ReactiveEvaluationStep {
     return rolloutStrategy
         .isInRollout(context.gateId(), gateContext, context.rolloutPercentage())
         .map(
-            inRollout ->
-                inRollout
-                    ? AccessDecision.allowed()
-                    : AccessDecision.denied(context.gateId(), DeniedReason.ROLLOUT_EXCLUDED));
+            inRollout -> {
+              if (inRollout) {
+                return AccessDecision.allowed();
+              }
+              return AccessDecision.denied(context.gateId(), DeniedReason.ROLLOUT_EXCLUDED);
+            });
   }
 }

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/InMemoryReactiveConditionProvider.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/InMemoryReactiveConditionProvider.java
@@ -22,7 +22,7 @@ public class InMemoryReactiveConditionProvider implements ReactiveConditionProvi
   @Override
   public Mono<String> getCondition(String gateId) {
     String condition = conditions.get(gateId);
-    return condition != null ? Mono.just(condition) : Mono.empty();
+    return Mono.justOrEmpty(condition);
   }
 
   /**

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/InMemoryReactiveRolloutPercentageProvider.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/InMemoryReactiveRolloutPercentageProvider.java
@@ -23,7 +23,7 @@ public class InMemoryReactiveRolloutPercentageProvider
   @Override
   public Mono<Integer> getRolloutPercentage(String gateId) {
     Integer percentage = rolloutPercentages.get(gateId);
-    return percentage != null ? Mono.just(percentage) : Mono.empty();
+    return Mono.justOrEmpty(percentage);
   }
 
   /**

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/MutableInMemoryReactiveConditionProvider.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/MutableInMemoryReactiveConditionProvider.java
@@ -22,7 +22,7 @@ public class MutableInMemoryReactiveConditionProvider implements MutableReactive
   @Override
   public Mono<String> getCondition(String gateId) {
     String condition = conditions.get(gateId);
-    return condition != null ? Mono.just(condition) : Mono.empty();
+    return Mono.justOrEmpty(condition);
   }
 
   /** {@inheritDoc} */

--- a/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/MutableInMemoryReactiveRolloutPercentageProvider.java
+++ b/reactive-core/src/main/java/net/brightroom/endpointgate/reactive/core/provider/MutableInMemoryReactiveRolloutPercentageProvider.java
@@ -23,7 +23,7 @@ public class MutableInMemoryReactiveRolloutPercentageProvider
   @Override
   public Mono<Integer> getRolloutPercentage(String gateId) {
     Integer percentage = rolloutPercentages.get(gateId);
-    return percentage != null ? Mono.just(percentage) : Mono.empty();
+    return Mono.justOrEmpty(percentage);
   }
 
   /** {@inheritDoc} */

--- a/reactive-core/src/test/java/net/brightroom/endpointgate/reactive/core/provider/MutableInMemoryReactiveConditionProviderTest.java
+++ b/reactive-core/src/test/java/net/brightroom/endpointgate/reactive/core/provider/MutableInMemoryReactiveConditionProviderTest.java
@@ -1,0 +1,122 @@
+package net.brightroom.endpointgate.reactive.core.provider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Test;
+
+class MutableInMemoryReactiveConditionProviderTest {
+
+  @Test
+  void getCondition_returnsCondition_whenExists() {
+    var provider =
+        new MutableInMemoryReactiveConditionProvider(Map.of("gate-a", "headers['X-Beta'] != null"));
+
+    assertEquals("headers['X-Beta'] != null", provider.getCondition("gate-a").block());
+  }
+
+  @Test
+  void getCondition_returnsEmpty_whenNotExists() {
+    var provider = new MutableInMemoryReactiveConditionProvider(Map.of());
+
+    assertNull(provider.getCondition("nonexistent").block());
+  }
+
+  @Test
+  void setCondition_addsNewEntry() {
+    var provider = new MutableInMemoryReactiveConditionProvider(Map.of());
+
+    provider.setCondition("gate-a", "params['debug'] != null").block();
+
+    assertEquals("params['debug'] != null", provider.getCondition("gate-a").block());
+    assertEquals(Map.of("gate-a", "params['debug'] != null"), provider.getConditions().block());
+  }
+
+  @Test
+  void setCondition_updatesExistingEntry() {
+    var provider =
+        new MutableInMemoryReactiveConditionProvider(Map.of("gate-a", "headers['X-Beta'] != null"));
+
+    provider.setCondition("gate-a", "params['debug'] != null").block();
+
+    assertEquals("params['debug'] != null", provider.getCondition("gate-a").block());
+  }
+
+  @Test
+  void getConditions_returnsSnapshotOfAllConditions() {
+    var provider =
+        new MutableInMemoryReactiveConditionProvider(
+            Map.of("gate-a", "headers['X-Beta'] != null", "gate-b", "params['debug'] != null"));
+
+    var conditions = provider.getConditions().block();
+
+    assertEquals(
+        Map.of("gate-a", "headers['X-Beta'] != null", "gate-b", "params['debug'] != null"),
+        conditions);
+  }
+
+  @Test
+  void getConditions_returnsImmutableCopy_notAffectedBySubsequentMutations() {
+    var provider =
+        new MutableInMemoryReactiveConditionProvider(Map.of("gate-a", "headers['X-Beta'] != null"));
+    var snapshot = provider.getConditions().block();
+
+    provider.setCondition("gate-a", "params['debug'] != null").block();
+
+    assertEquals(
+        "headers['X-Beta'] != null",
+        snapshot.get("gate-a"),
+        "snapshot must not reflect subsequent mutations");
+  }
+
+  @Test
+  void removeCondition_removesExistingEntry() {
+    var provider =
+        new MutableInMemoryReactiveConditionProvider(Map.of("gate-a", "headers['X-Beta'] != null"));
+
+    Boolean removed = provider.removeCondition("gate-a").block();
+
+    assertTrue(removed);
+    assertNull(provider.getCondition("gate-a").block());
+    assertTrue(provider.getConditions().block().isEmpty());
+  }
+
+  @Test
+  void removeCondition_isNoOp_whenEntryDoesNotExist() {
+    var provider =
+        new MutableInMemoryReactiveConditionProvider(Map.of("gate-a", "headers['X-Beta'] != null"));
+
+    Boolean removed = provider.removeCondition("nonexistent").block();
+
+    assertFalse(removed);
+    assertEquals("headers['X-Beta'] != null", provider.getCondition("gate-a").block());
+    assertEquals(Map.of("gate-a", "headers['X-Beta'] != null"), provider.getConditions().block());
+  }
+
+  @Test
+  void concurrentSetCondition_doesNotCorruptState() {
+    var provider = new MutableInMemoryReactiveConditionProvider(Map.of());
+    int threadCount = 100;
+    List<String> gates = new ArrayList<>();
+    for (int i = 0; i < threadCount; i++) {
+      gates.add("gate-" + i);
+    }
+
+    try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      for (String gate : gates) {
+        executor.submit(() -> provider.setCondition(gate, "headers['X-Beta'] != null").block());
+      }
+    }
+
+    assertEquals(threadCount, provider.getConditions().block().size());
+    gates.forEach(
+        gate -> assertEquals("headers['X-Beta'] != null", provider.getCondition(gate).block()));
+  }
+}

--- a/spring/core/src/main/java/net/brightroom/endpointgate/spring/core/properties/GateProperties.java
+++ b/spring/core/src/main/java/net/brightroom/endpointgate/spring/core/properties/GateProperties.java
@@ -87,7 +87,11 @@ public class GateProperties {
 
   // for property binding
   void setCondition(String condition) {
-    this.condition = condition != null ? condition : "";
+    if (condition != null) {
+      this.condition = condition;
+    } else {
+      this.condition = "";
+    }
   }
 
   // for property binding

--- a/spring/core/src/test/java/net/brightroom/endpointgate/spring/core/event/EndpointGateChangedEventTest.java
+++ b/spring/core/src/test/java/net/brightroom/endpointgate/spring/core/event/EndpointGateChangedEventTest.java
@@ -1,0 +1,52 @@
+package net.brightroom.endpointgate.spring.core.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class EndpointGateChangedEventTest {
+
+  private static final Object SOURCE = new Object();
+
+  @Test
+  void constructor_withEnabledOnly_setsFieldsCorrectly() {
+    var event = new EndpointGateChangedEvent(SOURCE, "gate-a", true);
+
+    assertEquals("gate-a", event.gateId());
+    assertTrue(event.enabled());
+    assertNull(event.rolloutPercentage());
+    assertNull(event.condition());
+    assertEquals(SOURCE, event.getSource());
+  }
+
+  @Test
+  void constructor_withEnabledAndRollout_setsFieldsCorrectly() {
+    var event = new EndpointGateChangedEvent(SOURCE, "gate-a", false, 50);
+
+    assertEquals("gate-a", event.gateId());
+    assertEquals(false, event.enabled());
+    assertEquals(50, event.rolloutPercentage());
+    assertNull(event.condition());
+  }
+
+  @Test
+  void constructor_withAllFields_setsFieldsCorrectly() {
+    var event =
+        new EndpointGateChangedEvent(SOURCE, "gate-a", true, 75, "headers['X-Beta'] != null");
+
+    assertEquals("gate-a", event.gateId());
+    assertTrue(event.enabled());
+    assertEquals(75, event.rolloutPercentage());
+    assertEquals("headers['X-Beta'] != null", event.condition());
+  }
+
+  @Test
+  void constructor_withNullRolloutAndCondition_returnsNull() {
+    var event = new EndpointGateChangedEvent(SOURCE, "gate-a", true, null, null);
+
+    assertNull(event.rolloutPercentage());
+    assertNull(event.condition());
+  }
+}

--- a/spring/core/src/test/java/net/brightroom/endpointgate/spring/core/event/EndpointGateRemovedEventTest.java
+++ b/spring/core/src/test/java/net/brightroom/endpointgate/spring/core/event/EndpointGateRemovedEventTest.java
@@ -1,0 +1,18 @@
+package net.brightroom.endpointgate.spring.core.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class EndpointGateRemovedEventTest {
+
+  @Test
+  void constructor_setsGateIdAndSource() {
+    Object source = new Object();
+
+    var event = new EndpointGateRemovedEvent(source, "gate-a");
+
+    assertEquals("gate-a", event.gateId());
+    assertEquals(source, event.getSource());
+  }
+}

--- a/spring/core/src/test/java/net/brightroom/endpointgate/spring/core/properties/ConditionPropertiesTest.java
+++ b/spring/core/src/test/java/net/brightroom/endpointgate/spring/core/properties/ConditionPropertiesTest.java
@@ -1,0 +1,25 @@
+package net.brightroom.endpointgate.spring.core.properties;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ConditionPropertiesTest {
+
+  @Test
+  void failOnError_defaultsToTrue() {
+    var props = new ConditionProperties();
+
+    assertTrue(props.failOnError());
+  }
+
+  @Test
+  void setFailOnError_updatesValue() {
+    var props = new ConditionProperties();
+
+    props.setFailOnError(false);
+
+    assertFalse(props.failOnError());
+  }
+}

--- a/spring/core/src/test/java/net/brightroom/endpointgate/spring/core/properties/ResponsePropertiesTest.java
+++ b/spring/core/src/test/java/net/brightroom/endpointgate/spring/core/properties/ResponsePropertiesTest.java
@@ -1,0 +1,33 @@
+package net.brightroom.endpointgate.spring.core.properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ResponsePropertiesTest {
+
+  @Test
+  void type_defaultsToJson() {
+    var props = new ResponseProperties();
+
+    assertEquals(ResponseType.JSON, props.type());
+  }
+
+  @Test
+  void setType_updatesValue() {
+    var props = new ResponseProperties();
+
+    props.setType(ResponseType.HTML);
+
+    assertEquals(ResponseType.HTML, props.type());
+  }
+
+  @Test
+  void setType_plainText_updatesValue() {
+    var props = new ResponseProperties();
+
+    props.setType(ResponseType.PLAIN_TEXT);
+
+    assertEquals(ResponseType.PLAIN_TEXT, props.type());
+  }
+}

--- a/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/condition/ServerHttpConditionVariables.java
+++ b/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/condition/ServerHttpConditionVariables.java
@@ -38,13 +38,19 @@ public final class ServerHttpConditionVariables {
               if (!cookieList.isEmpty()) cookies.put(name, cookieList.getFirst().getValue());
             });
     InetSocketAddress remoteAddr = request.getRemoteAddress();
+    String remoteAddress;
+    if (remoteAddr != null) {
+      remoteAddress = remoteAddr.getHostString();
+    } else {
+      remoteAddress = "";
+    }
     return new ConditionVariablesBuilder()
         .headers(headers)
         .params(params)
         .cookies(cookies)
         .path(request.getPath().value())
         .method(request.getMethod().name())
-        .remoteAddress(remoteAddr != null ? remoteAddr.getHostString() : "")
+        .remoteAddress(remoteAddress)
         .build();
   }
 }


### PR DESCRIPTION
## Summary

- **H-1〜H-4**: CG-1（三項演算子禁止）違反をすべて解消
  - `core`: `InMemoryRolloutPercentageProvider` / `MutableInMemoryRolloutPercentageProvider` を `if-else` に変換
  - `reactive-core`: 4 Provider クラスを `Mono.justOrEmpty()` に変換、`ReactiveRolloutEvaluationStep` の `.map()` ラムダを `if-else` に変換
  - `spring-core`: `GateProperties.setCondition()` を `if-else` に変換
  - `spring-webflux`: `ServerHttpConditionVariables.build()` をローカル変数 + `if-else` に変換
- **M-1**: `MutableInMemoryReactiveConditionProviderTest` を新規作成（getCondition / setCondition / removeCondition / getConditions / 並行テスト）
- **L-1**: `EndpointGateChangedEventTest` / `EndpointGateRemovedEventTest` を新規作成
- **L-2**: `ConditionPropertiesTest` / `ResponsePropertiesTest` を新規作成

## Test plan

- [ ] `./gradlew :core:test` — H-1 修正後の既存テストが通過すること
- [ ] `./gradlew :reactive-core:test` — H-2 修正後の既存テストおよび新規 `MutableInMemoryReactiveConditionProviderTest` が通過すること
- [ ] `./gradlew :spring:spring-core:test` — H-3 修正後の既存テストおよび新規イベント・プロパティテストが通過すること
- [ ] `./gradlew :spring:spring-webflux:test` — H-4 修正後の既存テストが通過すること
- [ ] `./gradlew check` — 全モジュールのユニット・統合テストおよび Spotless チェックが通過すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)