### PR TITLE
Close #41: Fix rolloutFallback unreachable for YAML-defined gates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ Built-in `AccessDeniedInterceptResolution` implementations (selected by `endpoin
 | Property | Default | Description |
 |---|---|---|
 | `endpoint-gate.gates.<id>.enabled` | `true` | Whether the gate is enabled |
-| `endpoint-gate.gates.<id>.rollout` | `100` | Rollout percentage (0-100) |
+| `endpoint-gate.gates.<id>.rollout` | — | Rollout percentage (0-100). If omitted, interceptor/aspect use `100`; `HandlerFilterFunction` uses the `rolloutFallback` argument of `of(gateId, rolloutFallback)` |
 | `endpoint-gate.gates.<id>.condition` | `""` | SpEL condition expression |
 | `endpoint-gate.gates.<id>.schedule.start` | — | Schedule start time (ISO 8601) |
 | `endpoint-gate.gates.<id>.schedule.end` | — | Schedule end time (ISO 8601) |

--- a/spring/core/src/main/java/net/brightroom/endpointgate/spring/core/properties/EndpointGateProperties.java
+++ b/spring/core/src/main/java/net/brightroom/endpointgate/spring/core/properties/EndpointGateProperties.java
@@ -55,7 +55,12 @@ public class EndpointGateProperties {
    */
   public Map<String, Integer> rolloutPercentages() {
     var result = new HashMap<String, Integer>();
-    gates.forEach((id, config) -> result.put(id, config.rollout()));
+    gates.forEach(
+        (id, config) -> {
+          if (config.rollout() != null) {
+            result.put(id, config.rollout());
+          }
+        });
     return Map.copyOf(result);
   }
 

--- a/spring/core/src/main/java/net/brightroom/endpointgate/spring/core/properties/GateProperties.java
+++ b/spring/core/src/main/java/net/brightroom/endpointgate/spring/core/properties/GateProperties.java
@@ -28,7 +28,7 @@ package net.brightroom.endpointgate.spring.core.properties;
 public class GateProperties {
 
   private boolean enabled = true;
-  private int rollout = 100;
+  private Integer rollout;
   private String condition = "";
   private ScheduleProperties schedule;
 
@@ -42,14 +42,15 @@ public class GateProperties {
   }
 
   /**
-   * Returns the rollout percentage for this gate (0–100).
+   * Returns the rollout percentage for this gate (0–100), or {@code null} if not explicitly
+   * configured.
    *
-   * <p>100 means fully enabled (all requests). 0 means effectively disabled (no requests even if
-   * the gate is enabled).
+   * <p>{@code null} indicates that no rollout percentage was specified in configuration, allowing
+   * fallback values to be applied by the caller.
    *
-   * @return the rollout percentage
+   * @return the rollout percentage, or {@code null} if not configured
    */
-  public int rollout() {
+  public Integer rollout() {
     return rollout;
   }
 

--- a/spring/core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring/core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -14,8 +14,7 @@
     {
       "name": "endpoint-gate.gates.[*].rollout",
       "type": "java.lang.Integer",
-      "description": "Rollout percentage for this endpoint gate (0-100). 100 means fully rolled out to all requests; 0 means no requests even if enabled.",
-      "defaultValue": 100
+      "description": "Rollout percentage for this endpoint gate (0-100). 100 means fully rolled out to all requests; 0 means no requests even if enabled. If omitted, interceptor and aspect use 100; HandlerFilterFunction uses the rolloutFallback argument of of(gateId, rolloutFallback)."
     },
     {
       "name": "endpoint-gate.gates.[*].condition",

--- a/spring/core/src/test/java/net/brightroom/endpointgate/spring/core/autoconfigure/EndpointGateAutoConfigurationMultiplePropertiesTest.java
+++ b/spring/core/src/test/java/net/brightroom/endpointgate/spring/core/autoconfigure/EndpointGateAutoConfigurationMultiplePropertiesTest.java
@@ -30,10 +30,9 @@ class EndpointGateAutoConfigurationMultiplePropertiesTest {
 
   @Test
   void shouldLoadRolloutPercentages() {
+    // g1 and g2 have no rollout configured in YAML, so they are excluded from rolloutPercentages()
     Map<String, Integer> rolloutPercentages = endpointGateProperties.rolloutPercentages();
-    assertEquals(2, rolloutPercentages.size());
-    assertEquals(100, rolloutPercentages.get("g1"));
-    assertEquals(100, rolloutPercentages.get("g2"));
+    assertTrue(rolloutPercentages.isEmpty());
   }
 
   @Test

--- a/spring/core/src/test/java/net/brightroom/endpointgate/spring/core/properties/EndpointGatePropertiesTest.java
+++ b/spring/core/src/test/java/net/brightroom/endpointgate/spring/core/properties/EndpointGatePropertiesTest.java
@@ -1,0 +1,63 @@
+package net.brightroom.endpointgate.spring.core.properties;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class EndpointGatePropertiesTest {
+
+  @Test
+  void rolloutPercentages_excludesGatesWithoutRollout() {
+    GateProperties withoutRollout = new GateProperties();
+
+    var gates = new HashMap<String, GateProperties>();
+    gates.put("no-rollout-gate", withoutRollout);
+
+    EndpointGateProperties properties = new EndpointGateProperties();
+    properties.setGates(gates);
+
+    Map<String, Integer> result = properties.rolloutPercentages();
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void rolloutPercentages_includesGatesWithRollout() {
+    GateProperties withRollout = new GateProperties();
+    withRollout.setRollout(50);
+
+    var gates = new HashMap<String, GateProperties>();
+    gates.put("rollout-gate", withRollout);
+
+    EndpointGateProperties properties = new EndpointGateProperties();
+    properties.setGates(gates);
+
+    Map<String, Integer> result = properties.rolloutPercentages();
+
+    assertEquals(1, result.size());
+    assertEquals(50, result.get("rollout-gate"));
+  }
+
+  @Test
+  void rolloutPercentages_handlesMixedGates() {
+    GateProperties withRollout = new GateProperties();
+    withRollout.setRollout(75);
+
+    GateProperties withoutRollout = new GateProperties();
+
+    var gates = new HashMap<String, GateProperties>();
+    gates.put("rollout-gate", withRollout);
+    gates.put("no-rollout-gate", withoutRollout);
+
+    EndpointGateProperties properties = new EndpointGateProperties();
+    properties.setGates(gates);
+
+    Map<String, Integer> result = properties.rolloutPercentages();
+
+    assertEquals(1, result.size());
+    assertEquals(75, result.get("rollout-gate"));
+    assertFalse(result.containsKey("no-rollout-gate"));
+  }
+}

--- a/spring/core/src/test/java/net/brightroom/endpointgate/spring/core/properties/GatePropertiesTest.java
+++ b/spring/core/src/test/java/net/brightroom/endpointgate/spring/core/properties/GatePropertiesTest.java
@@ -8,6 +8,12 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class GatePropertiesTest {
 
+  @Test
+  void rollout_defaultsToNull() {
+    GateProperties config = new GateProperties();
+    assertNull(config.rollout());
+  }
+
   @ParameterizedTest
   @ValueSource(ints = {0, 1, 50, 99, 100})
   void setRollout_shouldAcceptValidValues(int rollout) {

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateHandlerFilterFunctionRolloutIntegrationTest.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateHandlerFilterFunctionRolloutIntegrationTest.java
@@ -33,10 +33,16 @@ import reactor.core.publisher.Mono;
  *
  * <p>A real Netty server is used (instead of {@code @WebFluxTest}) to ensure the full Spring
  * WebFlux pipeline — including context propagation of {@code ServerWebExchange} — is exercised.
+ *
+ * <p>Also verifies that {@link EndpointGateHandlerFilterFunction#of(String, int)} uses the {@code
+ * rolloutFallback} argument when {@code rollout} is not configured in YAML.
  */
 @SpringBootTest(
     webEnvironment = WebEnvironment.RANDOM_PORT,
-    properties = {"endpoint-gate.gates.rollout-feature.enabled=true"})
+    properties = {
+      "endpoint-gate.gates.rollout-feature.enabled=true",
+      "endpoint-gate.gates.no-rollout-feature.enabled=true"
+    })
 class EndpointGateHandlerFilterFunctionRolloutIntegrationTest {
 
   private static final EndpointGateContext FIXED_CONTEXT = new EndpointGateContext("fixed-user-id");
@@ -59,6 +65,15 @@ class EndpointGateHandlerFilterFunctionRolloutIntegrationTest {
       return route()
           .GET("/functional/rollout-test", req -> ServerResponse.ok().bodyValue("Allowed"))
           .filter(endpointGateFilter.of("rollout-feature", 50))
+          .build();
+    }
+
+    @Bean
+    RouterFunction<ServerResponse> functionalRolloutFallbackTestRoute(
+        EndpointGateHandlerFilterFunction endpointGateFilter) {
+      return route()
+          .GET("/functional/rollout-fallback-test", req -> ServerResponse.ok().bodyValue("Allowed"))
+          .filter(endpointGateFilter.of("no-rollout-feature", 0))
           .build();
     }
   }
@@ -104,5 +119,17 @@ class EndpointGateHandlerFilterFunctionRolloutIntegrationTest {
         .isOk()
         .expectBody(String.class)
         .isEqualTo("Allowed");
+  }
+
+  @Test
+  void rolloutFallback_isApplied_whenRolloutNotConfiguredInYaml() {
+    // no-rollout-feature has no rollout configured in YAML; of("no-rollout-feature", 0) uses 0 as
+    // fallback, meaning no requests are allowed.
+    webTestClient
+        .get()
+        .uri("/functional/rollout-fallback-test")
+        .exchange()
+        .expectStatus()
+        .isForbidden();
   }
 }

--- a/spring/webmvc/src/integrationTest/java/net/brightroom/endpointgate/spring/webmvc/EndpointGateHandlerFilterFunctionRolloutIntegrationTest.java
+++ b/spring/webmvc/src/integrationTest/java/net/brightroom/endpointgate/spring/webmvc/EndpointGateHandlerFilterFunctionRolloutIntegrationTest.java
@@ -31,12 +31,15 @@ import org.springframework.web.servlet.function.ServerResponse;
  *   <li>Rollout decision is deterministic for a fixed user identifier.
  *   <li>{@link EndpointGateHandlerFilterFunction#of(String, int)} correctly applies rollout control
  *       via {@code ServerRequest.servletRequest()} in the MVC pipeline.
+ *   <li>{@link EndpointGateHandlerFilterFunction#of(String, int)} uses the {@code rolloutFallback}
+ *       argument when {@code rollout} is not configured in YAML.
  * </ul>
  */
 @WebMvcTest(
     properties = {
       "endpoint-gate.gates.rollout-gate.enabled=true",
-      "endpoint-gate.gates.rollout-gate.rollout=50"
+      "endpoint-gate.gates.rollout-gate.rollout=50",
+      "endpoint-gate.gates.no-rollout-gate.enabled=true"
     })
 @Import({
   EndpointGateMvcTestAutoConfiguration.class,
@@ -65,6 +68,15 @@ class EndpointGateHandlerFilterFunctionRolloutIntegrationTest {
       return route()
           .GET("/functional/rollout-test", req -> ServerResponse.ok().body("Allowed"))
           .filter(endpointGateFilter.of("rollout-gate", 50))
+          .build();
+    }
+
+    @Bean
+    RouterFunction<ServerResponse> functionalRolloutFallbackTestRoute(
+        EndpointGateHandlerFilterFunction endpointGateFilter) {
+      return route()
+          .GET("/functional/rollout-fallback-test", req -> ServerResponse.ok().body("Allowed"))
+          .filter(endpointGateFilter.of("no-rollout-gate", 0))
           .build();
     }
   }
@@ -103,5 +115,14 @@ class EndpointGateHandlerFilterFunctionRolloutIntegrationTest {
         .perform(MockMvcRequestBuilders.get("/functional/rollout-test"))
         .andExpect(MockMvcResultMatchers.status().isOk())
         .andExpect(MockMvcResultMatchers.content().string("Allowed"));
+  }
+
+  @Test
+  void rolloutFallback_isApplied_whenRolloutNotConfiguredInYaml() throws Exception {
+    // no-rollout-gate has no rollout configured in YAML; of("no-rollout-gate", 0) uses 0 as
+    // fallback, meaning no requests are allowed.
+    mockMvc
+        .perform(MockMvcRequestBuilders.get("/functional/rollout-fallback-test"))
+        .andExpect(MockMvcResultMatchers.status().isForbidden());
   }
 }


### PR DESCRIPTION
## Summary

- `GateProperties.rollout` の型を `int` から `Integer` (nullable) に変更し、デフォルトを `null` にした
- `EndpointGateProperties.rolloutPercentages()` で `rollout == null` のエントリを除外するよう修正
- YAML で `rollout` を未指定のゲートに対して `getRolloutPercentage()` が `OptionalInt.empty()` を返すようになり、`EndpointGateHandlerFilterFunction.of(gateId, rolloutFallback)` の `rolloutFallback` に到達できるようになった

## Root Cause

`GateProperties.rollout` のデフォルト値が `100` であったため、YAML で `rollout` を未指定のゲートも `rolloutPercentages()` に `100` として含まれていた。結果として `InMemoryRolloutPercentageProvider.getRolloutPercentage()` が常に `OptionalInt.of(100)` を返し、`.orElse(rolloutFallback)` に到達しなかった。

## Test plan

- [x] `GatePropertiesTest`: `rollout` のデフォルト値が `null` であること
- [x] `EndpointGatePropertiesTest` (新規): `rolloutPercentages()` が rollout 未指定ゲートを除外し、明示指定ゲートのみを返すこと
- [x] WebMVC 統合テスト: `rolloutFallback=0` のゲート（YAML rollout 未指定）が常に 403 を返すこと
- [x] WebFlux 統合テスト: 同上
- [x] `./gradlew check` 全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)