### PR TITLE
Fix sonatypeCentralUpload depending on examples javadocJar

### DIFF
--- a/gradle-scripts/src/main/kotlin/publish-plugin.gradle.kts
+++ b/gradle-scripts/src/main/kotlin/publish-plugin.gradle.kts
@@ -70,7 +70,7 @@ tasks {
         // preventing partial uploads when a sibling module's javadoc fails.
         rootProject.subprojects.forEach { sub ->
             if (sub != project) {
-                sub.plugins.withId("java") {
+                sub.plugins.withId("maven-publish") {
                     dependsOn("${sub.path}:javadocJar")
                 }
             }


### PR DESCRIPTION
## Summary
- `sonatypeCentralUpload` タスクが `java` プラグインを持つ全サブプロジェクトの `javadocJar` に依存していたため、公開対象外の `examples` モジュールでも `javadoc`/`javadocJar` が実行され、大量の警告が発生していた
- 依存判定を `maven-publish` プラグインに変更し、公開対象モジュールのみに限定

## Test plan
- [ ] `./gradlew sonatypeCentralUpload --dry-run` で examples モジュールの javadoc タスクが含まれないことを確認
- [ ] `./gradlew build` が正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)