### PR TITLE
Fix review comments: apply coding guidelines and add missing tests

### DIFF
--- a/core/src/main/java/net/brightroom/endpointgate/core/evaluation/AccessDecision.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/evaluation/AccessDecision.java
@@ -80,10 +80,10 @@ public sealed interface AccessDecision {
    *
    * @param gateId the gate identifier that was denied
    * @param reason the reason for denial
-   * @param retryAfter the time after which the client may retry
+   * @param retryAfter the time after which the client may retry, or {@code null} if not applicable
    * @return a new {@code Denied} instance
    */
-  static AccessDecision denied(String gateId, DeniedReason reason, Instant retryAfter) {
+  static AccessDecision denied(String gateId, DeniedReason reason, @Nullable Instant retryAfter) {
     return new Denied(gateId, reason, retryAfter);
   }
 }

--- a/core/src/main/java/net/brightroom/endpointgate/core/exception/EndpointGateScheduleInactiveException.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/exception/EndpointGateScheduleInactiveException.java
@@ -22,7 +22,7 @@ public class EndpointGateScheduleInactiveException extends EndpointGateAccessDen
   private final @Nullable Instant retryAfter;
 
   /**
-   * Constructor.
+   * Creates a new {@code EndpointGateScheduleInactiveException} for the specified gate.
    *
    * @param gateId the identifier of the gate that is not available
    * @param retryAfter the schedule start time as an {@link Instant}, or {@code null} if the

--- a/core/src/main/java/net/brightroom/endpointgate/core/provider/Schedule.java
+++ b/core/src/main/java/net/brightroom/endpointgate/core/provider/Schedule.java
@@ -58,7 +58,8 @@ public record Schedule(
    */
   public boolean isActive(Instant now) {
     ZoneId zone = resolveZone();
-    LocalDateTime localNow = now.atZone(zone).toLocalDateTime();
+    ZonedDateTime zonedNow = now.atZone(zone);
+    LocalDateTime localNow = zonedNow.toLocalDateTime();
     if (start != null) {
       if (localNow.isBefore(start)) {
         return false;

--- a/spring/actuator/src/main/java/net/brightroom/endpointgate/spring/actuator/endpoint/EndpointGateEndpoint.java
+++ b/spring/actuator/src/main/java/net/brightroom/endpointgate/spring/actuator/endpoint/EndpointGateEndpoint.java
@@ -4,6 +4,7 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Map;
+import java.util.Optional;
 import net.brightroom.endpointgate.core.provider.MutableConditionProvider;
 import net.brightroom.endpointgate.core.provider.MutableEndpointGateProvider;
 import net.brightroom.endpointgate.core.provider.MutableRolloutPercentageProvider;
@@ -66,9 +67,7 @@ public class EndpointGateEndpoint {
    */
   @ReadOperation
   public EndpointGateEndpointResponse gate(@Selector String gateId) {
-    if (gateId == null || gateId.isBlank()) {
-      throw new IllegalArgumentException("gateId must not be null or blank");
-    }
+    validateGateId(gateId);
     return new EndpointGateEndpointResponse(
         gateId,
         provider.isGateEnabled(gateId),
@@ -124,39 +123,14 @@ public class EndpointGateEndpoint {
       @Nullable LocalDateTime scheduleEnd,
       @Nullable String scheduleTimezone,
       @Nullable Boolean removeSchedule) {
-    if (gateId == null || gateId.isBlank()) {
-      throw new IllegalArgumentException("gateId must not be null or blank");
-    }
-    if (rollout != null && (rollout < 0 || rollout > 100)) {
-      throw new IllegalArgumentException("rollout must be between 0 and 100, but was: " + rollout);
-    }
+    validateGateId(gateId);
+    validateRollout(rollout);
     provider.setGateEnabled(gateId, enabled);
     if (rollout != null) {
       rolloutProvider.setRolloutPercentage(gateId, rollout);
     }
-    if (condition != null) {
-      if (condition.isEmpty()) {
-        conditionProvider.removeCondition(gateId);
-      } else {
-        conditionProvider.setCondition(gateId, condition);
-      }
-    }
-    if (Boolean.TRUE.equals(removeSchedule)) {
-      scheduleProvider.removeSchedule(gateId);
-      eventPublisher.publishEvent(new EndpointGateScheduleChangedEvent(this, gateId, null));
-    } else if (scheduleStart != null || scheduleEnd != null || scheduleTimezone != null) {
-      if (scheduleStart == null && scheduleEnd == null) {
-        throw new IllegalArgumentException(
-            "At least one of scheduleStart or scheduleEnd is required when setting a schedule");
-      }
-      ZoneId timezone = defaultScheduleTimezone;
-      if (scheduleTimezone != null && !scheduleTimezone.isEmpty()) {
-        timezone = ZoneId.of(scheduleTimezone);
-      }
-      Schedule newSchedule = new Schedule(scheduleStart, scheduleEnd, timezone);
-      scheduleProvider.setSchedule(gateId, newSchedule);
-      eventPublisher.publishEvent(new EndpointGateScheduleChangedEvent(this, gateId, newSchedule));
-    }
+    updateCondition(gateId, condition);
+    processScheduleUpdate(gateId, scheduleStart, scheduleEnd, scheduleTimezone, removeSchedule);
     eventPublisher.publishEvent(
         new EndpointGateChangedEvent(this, gateId, enabled, rollout, condition));
     return buildGatesResponse();
@@ -174,9 +148,7 @@ public class EndpointGateEndpoint {
    */
   @DeleteOperation
   public void deleteGate(@Selector String gateId) {
-    if (gateId == null || gateId.isBlank()) {
-      throw new IllegalArgumentException("gateId must not be null or blank");
-    }
+    validateGateId(gateId);
     boolean removed = provider.removeGate(gateId);
     rolloutProvider.removeRolloutPercentage(gateId);
     conditionProvider.removeCondition(gateId);
@@ -207,16 +179,13 @@ public class EndpointGateEndpoint {
 
   @Nullable
   private ScheduleEndpointResponse buildScheduleResponse(String gateId) {
-    return scheduleProvider
-        .getSchedule(gateId)
-        .map(
-            schedule ->
-                new ScheduleEndpointResponse(
-                    schedule.start(),
-                    schedule.end(),
-                    schedule.timezone(),
-                    schedule.isActive(clock.instant())))
-        .orElse(null);
+    Optional<Schedule> scheduleOpt = scheduleProvider.getSchedule(gateId);
+    if (scheduleOpt.isEmpty()) {
+      return null;
+    }
+    Schedule schedule = scheduleOpt.get();
+    return new ScheduleEndpointResponse(
+        schedule.start(), schedule.end(), schedule.timezone(), schedule.isActive(clock.instant()));
   }
 
   @Nullable
@@ -226,6 +195,77 @@ public class EndpointGateEndpoint {
     }
     return new ScheduleEndpointResponse(
         schedule.start(), schedule.end(), schedule.timezone(), schedule.isActive(clock.instant()));
+  }
+
+  private void validateGateId(String gateId) {
+    if (gateId == null) {
+      throw new IllegalArgumentException("gateId must not be null or blank");
+    }
+    if (gateId.isBlank()) {
+      throw new IllegalArgumentException("gateId must not be null or blank");
+    }
+  }
+
+  private void validateRollout(@Nullable Integer rollout) {
+    if (rollout == null) {
+      return;
+    }
+    if (rollout < 0) {
+      throw new IllegalArgumentException(
+          String.format("rollout must be between 0 and 100, but was: %d", rollout));
+    }
+    if (rollout > 100) {
+      throw new IllegalArgumentException(
+          String.format("rollout must be between 0 and 100, but was: %d", rollout));
+    }
+  }
+
+  private void updateCondition(String gateId, @Nullable String condition) {
+    if (condition == null) {
+      return;
+    }
+    if (condition.isEmpty()) {
+      conditionProvider.removeCondition(gateId);
+      return;
+    }
+    conditionProvider.setCondition(gateId, condition);
+  }
+
+  private void processScheduleUpdate(
+      String gateId,
+      @Nullable LocalDateTime scheduleStart,
+      @Nullable LocalDateTime scheduleEnd,
+      @Nullable String scheduleTimezone,
+      @Nullable Boolean removeSchedule) {
+    if (Boolean.TRUE.equals(removeSchedule)) {
+      scheduleProvider.removeSchedule(gateId);
+      eventPublisher.publishEvent(new EndpointGateScheduleChangedEvent(this, gateId, null));
+      return;
+    }
+    if (scheduleStart == null) {
+      if (scheduleEnd == null) {
+        if (scheduleTimezone == null) {
+          return;
+        }
+        throw new IllegalArgumentException(
+            "At least one of scheduleStart or scheduleEnd is required when setting a schedule");
+      }
+    }
+    ZoneId timezone = resolveScheduleTimezone(scheduleTimezone);
+    Schedule newSchedule = new Schedule(scheduleStart, scheduleEnd, timezone);
+    scheduleProvider.setSchedule(gateId, newSchedule);
+    eventPublisher.publishEvent(new EndpointGateScheduleChangedEvent(this, gateId, newSchedule));
+  }
+
+  @Nullable
+  private ZoneId resolveScheduleTimezone(@Nullable String scheduleTimezone) {
+    if (scheduleTimezone == null) {
+      return defaultScheduleTimezone;
+    }
+    if (scheduleTimezone.isEmpty()) {
+      return defaultScheduleTimezone;
+    }
+    return ZoneId.of(scheduleTimezone);
   }
 
   /**

--- a/spring/actuator/src/main/java/net/brightroom/endpointgate/spring/actuator/endpoint/ReactiveEndpointGateEndpoint.java
+++ b/spring/actuator/src/main/java/net/brightroom/endpointgate/spring/actuator/endpoint/ReactiveEndpointGateEndpoint.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import net.brightroom.endpointgate.core.provider.Schedule;
 import net.brightroom.endpointgate.reactive.core.provider.MutableReactiveConditionProvider;
 import net.brightroom.endpointgate.reactive.core.provider.MutableReactiveEndpointGateProvider;
@@ -68,13 +69,14 @@ public class ReactiveEndpointGateEndpoint {
    */
   @ReadOperation
   public EndpointGateEndpointResponse gate(@Selector String gateId) {
-    if (gateId == null || gateId.isBlank()) {
-      throw new IllegalArgumentException("gateId must not be null or blank");
-    }
+    validateGateId(gateId);
     var enabled = provider.isGateEnabled(gateId).block();
-    var rollout = rolloutProvider.getRolloutPercentage(gateId).blockOptional().orElse(100);
-    var condition = conditionProvider.getCondition(gateId).blockOptional().orElse(null);
-    var schedule = reactiveScheduleProvider.getSchedule(gateId).blockOptional().orElse(null);
+    Optional<Integer> rolloutOpt = rolloutProvider.getRolloutPercentage(gateId).blockOptional();
+    var rollout = rolloutOpt.orElse(100);
+    Optional<String> conditionOpt = conditionProvider.getCondition(gateId).blockOptional();
+    var condition = conditionOpt.orElse(null);
+    Optional<Schedule> scheduleOpt = reactiveScheduleProvider.getSchedule(gateId).blockOptional();
+    var schedule = scheduleOpt.orElse(null);
     return new EndpointGateEndpointResponse(
         gateId, Boolean.TRUE.equals(enabled), rollout, condition, buildScheduleResponse(schedule));
   }
@@ -126,39 +128,14 @@ public class ReactiveEndpointGateEndpoint {
       @Nullable LocalDateTime scheduleEnd,
       @Nullable String scheduleTimezone,
       @Nullable Boolean removeSchedule) {
-    if (gateId == null || gateId.isBlank()) {
-      throw new IllegalArgumentException("gateId must not be null or blank");
-    }
-    if (rollout != null && (rollout < 0 || rollout > 100)) {
-      throw new IllegalArgumentException("rollout must be between 0 and 100, but was: " + rollout);
-    }
+    validateGateId(gateId);
+    validateRollout(rollout);
     provider.setGateEnabled(gateId, enabled).block();
     if (rollout != null) {
       rolloutProvider.setRolloutPercentage(gateId, rollout).block();
     }
-    if (condition != null) {
-      if (condition.isEmpty()) {
-        conditionProvider.removeCondition(gateId).block();
-      } else {
-        conditionProvider.setCondition(gateId, condition).block();
-      }
-    }
-    if (Boolean.TRUE.equals(removeSchedule)) {
-      reactiveScheduleProvider.removeSchedule(gateId).block();
-      eventPublisher.publishEvent(new EndpointGateScheduleChangedEvent(this, gateId, null));
-    } else if (scheduleStart != null || scheduleEnd != null || scheduleTimezone != null) {
-      if (scheduleStart == null && scheduleEnd == null) {
-        throw new IllegalArgumentException(
-            "At least one of scheduleStart or scheduleEnd is required when setting a schedule");
-      }
-      ZoneId timezone = defaultScheduleTimezone;
-      if (scheduleTimezone != null && !scheduleTimezone.isEmpty()) {
-        timezone = ZoneId.of(scheduleTimezone);
-      }
-      Schedule newSchedule = new Schedule(scheduleStart, scheduleEnd, timezone);
-      reactiveScheduleProvider.setSchedule(gateId, newSchedule).block();
-      eventPublisher.publishEvent(new EndpointGateScheduleChangedEvent(this, gateId, newSchedule));
-    }
+    updateCondition(gateId, condition);
+    processScheduleUpdate(gateId, scheduleStart, scheduleEnd, scheduleTimezone, removeSchedule);
     eventPublisher.publishEvent(
         new EndpointGateChangedEvent(this, gateId, enabled, rollout, condition));
     return buildGatesResponse();
@@ -176,9 +153,7 @@ public class ReactiveEndpointGateEndpoint {
    */
   @DeleteOperation
   public void deleteGate(@Selector String gateId) {
-    if (gateId == null || gateId.isBlank()) {
-      throw new IllegalArgumentException("gateId must not be null or blank");
-    }
+    validateGateId(gateId);
     Boolean removed = provider.removeGate(gateId).block();
     rolloutProvider.removeRolloutPercentage(gateId).block();
     conditionProvider.removeCondition(gateId).block();
@@ -219,6 +194,77 @@ public class ReactiveEndpointGateEndpoint {
     }
     return new ScheduleEndpointResponse(
         schedule.start(), schedule.end(), schedule.timezone(), schedule.isActive(clock.instant()));
+  }
+
+  private void validateGateId(String gateId) {
+    if (gateId == null) {
+      throw new IllegalArgumentException("gateId must not be null or blank");
+    }
+    if (gateId.isBlank()) {
+      throw new IllegalArgumentException("gateId must not be null or blank");
+    }
+  }
+
+  private void validateRollout(@Nullable Integer rollout) {
+    if (rollout == null) {
+      return;
+    }
+    if (rollout < 0) {
+      throw new IllegalArgumentException(
+          String.format("rollout must be between 0 and 100, but was: %d", rollout));
+    }
+    if (rollout > 100) {
+      throw new IllegalArgumentException(
+          String.format("rollout must be between 0 and 100, but was: %d", rollout));
+    }
+  }
+
+  private void updateCondition(String gateId, @Nullable String condition) {
+    if (condition == null) {
+      return;
+    }
+    if (condition.isEmpty()) {
+      conditionProvider.removeCondition(gateId).block();
+      return;
+    }
+    conditionProvider.setCondition(gateId, condition).block();
+  }
+
+  private void processScheduleUpdate(
+      String gateId,
+      @Nullable LocalDateTime scheduleStart,
+      @Nullable LocalDateTime scheduleEnd,
+      @Nullable String scheduleTimezone,
+      @Nullable Boolean removeSchedule) {
+    if (Boolean.TRUE.equals(removeSchedule)) {
+      reactiveScheduleProvider.removeSchedule(gateId).block();
+      eventPublisher.publishEvent(new EndpointGateScheduleChangedEvent(this, gateId, null));
+      return;
+    }
+    if (scheduleStart == null) {
+      if (scheduleEnd == null) {
+        if (scheduleTimezone == null) {
+          return;
+        }
+        throw new IllegalArgumentException(
+            "At least one of scheduleStart or scheduleEnd is required when setting a schedule");
+      }
+    }
+    ZoneId timezone = resolveScheduleTimezone(scheduleTimezone);
+    Schedule newSchedule = new Schedule(scheduleStart, scheduleEnd, timezone);
+    reactiveScheduleProvider.setSchedule(gateId, newSchedule).block();
+    eventPublisher.publishEvent(new EndpointGateScheduleChangedEvent(this, gateId, newSchedule));
+  }
+
+  @Nullable
+  private ZoneId resolveScheduleTimezone(@Nullable String scheduleTimezone) {
+    if (scheduleTimezone == null) {
+      return defaultScheduleTimezone;
+    }
+    if (scheduleTimezone.isEmpty()) {
+      return defaultScheduleTimezone;
+    }
+    return ZoneId.of(scheduleTimezone);
   }
 
   /**

--- a/spring/core/src/main/java/net/brightroom/endpointgate/spring/core/properties/ScheduleProperties.java
+++ b/spring/core/src/main/java/net/brightroom/endpointgate/spring/core/properties/ScheduleProperties.java
@@ -86,21 +86,34 @@ public class ScheduleProperties {
 
   // for property binding
   void setStart(LocalDateTime start) {
-    if (start != null && this.end != null && start.isAfter(this.end)) {
-      throw new IllegalArgumentException(
-          "schedule.start must not be after schedule.end, but start=" + start + " end=" + this.end);
+    if (start == null) {
+      this.start = null;
+      return;
+    }
+    if (this.end != null) {
+      if (start.isAfter(this.end)) {
+        throw new IllegalArgumentException(
+            String.format(
+                "schedule.start must not be after schedule.end, but start=%s end=%s",
+                start, this.end));
+      }
     }
     this.start = start;
   }
 
   // for property binding
   void setEnd(LocalDateTime end) {
-    if (end != null && this.start != null && end.isBefore(this.start)) {
-      throw new IllegalArgumentException(
-          "schedule.end must not be before schedule.start, but end="
-              + end
-              + " start="
-              + this.start);
+    if (end == null) {
+      this.end = null;
+      return;
+    }
+    if (this.start != null) {
+      if (end.isBefore(this.start)) {
+        throw new IllegalArgumentException(
+            String.format(
+                "schedule.end must not be before schedule.start, but end=%s start=%s",
+                end, this.start));
+      }
     }
     this.end = end;
   }

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateHandlerFilterFunctionScheduleIntegrationTest.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/EndpointGateHandlerFilterFunctionScheduleIntegrationTest.java
@@ -1,0 +1,126 @@
+package net.brightroom.endpointgate.spring.webflux;
+
+import net.brightroom.endpointgate.spring.webflux.configuration.EndpointGateWebFluxTestAutoConfiguration;
+import net.brightroom.endpointgate.spring.webflux.endpoint.EndpointGateScheduleRouterConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * Verifies schedule-based endpoint gate control through the HandlerFilterFunction path:
+ *
+ * <ul>
+ *   <li>Property configuration → {@code InMemoryScheduleProvider} auto-wiring → filter → HTTP
+ *       response
+ *   <li>Active schedule (start in the past) → 200 OK
+ *   <li>Inactive schedule (start in the future) → 503 Service Unavailable + Retry-After header
+ *   <li>Inactive schedule (end only, no start) → 503 Service Unavailable, no Retry-After header
+ *   <li>Timezone-aware schedule → correctly evaluated in the configured timezone
+ * </ul>
+ */
+@WebFluxTest
+@Import({
+  EndpointGateWebFluxTestAutoConfiguration.class,
+  EndpointGateScheduleRouterConfiguration.class
+})
+@TestPropertySource(
+    properties = {
+      // active-scheduled-gate: start far in the past → always active
+      "endpoint-gate.gates.active-scheduled-gate.enabled=true",
+      "endpoint-gate.gates.active-scheduled-gate.schedule.start=2020-01-01T00:00:00",
+      // inactive-scheduled-gate: start far in the future → always inactive
+      "endpoint-gate.gates.inactive-scheduled-gate.enabled=true",
+      "endpoint-gate.gates.inactive-scheduled-gate.schedule.start=2099-01-01T00:00:00",
+      // end-only-inactive-scheduled-gate: end in the past, no start → inactive, no retry-after
+      "endpoint-gate.gates.end-only-inactive-scheduled-gate.enabled=true",
+      "endpoint-gate.gates.end-only-inactive-scheduled-gate.schedule.end=2020-01-01T00:00:00",
+      // timezone-scheduled-gate: start far in the past with timezone → always active
+      "endpoint-gate.gates.timezone-scheduled-gate.enabled=true",
+      "endpoint-gate.gates.timezone-scheduled-gate.schedule.start=2020-01-01T00:00:00",
+      "endpoint-gate.gates.timezone-scheduled-gate.schedule.timezone=Asia/Tokyo",
+    })
+class EndpointGateHandlerFilterFunctionScheduleIntegrationTest {
+
+  WebTestClient webTestClient;
+
+  @Autowired
+  EndpointGateHandlerFilterFunctionScheduleIntegrationTest(WebTestClient webTestClient) {
+    this.webTestClient = webTestClient;
+  }
+
+  @Test
+  void shouldAllowAccess_whenScheduleIsActive() {
+    webTestClient
+        .get()
+        .uri("/functional/schedule/active")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+
+  @Test
+  void shouldReturn503_whenScheduleIsInactive() {
+    webTestClient
+        .get()
+        .uri("/functional/schedule/inactive")
+        .exchange()
+        .expectStatus()
+        .isEqualTo(503)
+        .expectBody()
+        .json(
+            """
+            {
+              "status" : 503,
+              "title" : "Endpoint gate temporarily unavailable",
+              "type" : "https://github.com/bright-room/endpoint-gate#response-types"
+            }
+            """);
+  }
+
+  @Test
+  void shouldReturnRetryAfterHeader_whenScheduleIsInactive() {
+    webTestClient
+        .get()
+        .uri("/functional/schedule/inactive")
+        .exchange()
+        .expectStatus()
+        .isEqualTo(503)
+        .expectHeader()
+        .exists("Retry-After")
+        .expectHeader()
+        .value(
+            "Retry-After",
+            value ->
+                org.assertj.core.api.Assertions.assertThat(value)
+                    .matches("\\w{3}, \\d{1,2} \\w{3} \\d{4} \\d{2}:\\d{2}:\\d{2} GMT"));
+  }
+
+  @Test
+  void shouldReturn503WithoutRetryAfter_whenEndOnlyScheduleIsInactive() {
+    webTestClient
+        .get()
+        .uri("/functional/schedule/end-only-inactive")
+        .exchange()
+        .expectStatus()
+        .isEqualTo(503)
+        .expectHeader()
+        .doesNotExist("Retry-After");
+  }
+
+  @Test
+  void shouldAllowAccess_whenScheduleIsActiveWithTimezone() {
+    webTestClient
+        .get()
+        .uri("/functional/schedule/timezone")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(String.class)
+        .isEqualTo("Allowed");
+  }
+}

--- a/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/endpoint/EndpointGateScheduleRouterConfiguration.java
+++ b/spring/webflux/src/integrationTest/java/net/brightroom/endpointgate/spring/webflux/endpoint/EndpointGateScheduleRouterConfiguration.java
@@ -1,0 +1,61 @@
+package net.brightroom.endpointgate.spring.webflux.endpoint;
+
+import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
+import static org.springframework.web.reactive.function.server.RouterFunctions.route;
+
+import net.brightroom.endpointgate.spring.webflux.filter.EndpointGateHandlerFilterFunction;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+@Configuration
+public class EndpointGateScheduleRouterConfiguration {
+
+  private final EndpointGateHandlerFilterFunction endpointGateFilter;
+
+  @Bean
+  RouterFunction<ServerResponse> functionalActiveScheduleRoute() {
+    return route()
+        .GET("/functional/schedule/active", req -> ServerResponse.ok().bodyValue("Allowed"))
+        .filter(endpointGateFilter.of("active-scheduled-gate"))
+        .build();
+  }
+
+  @Bean
+  RouterFunction<ServerResponse> functionalInactiveScheduleRoute() {
+    return route()
+        .GET("/functional/schedule/inactive", req -> ServerResponse.ok().bodyValue("Allowed"))
+        .filter(endpointGateFilter.of("inactive-scheduled-gate"))
+        .build();
+  }
+
+  @Bean
+  RouterFunction<ServerResponse> functionalEndOnlyInactiveScheduleRoute() {
+    return route()
+        .GET(
+            "/functional/schedule/end-only-inactive",
+            req -> ServerResponse.ok().bodyValue("Allowed"))
+        .filter(endpointGateFilter.of("end-only-inactive-scheduled-gate"))
+        .build();
+  }
+
+  @Bean
+  RouterFunction<ServerResponse> functionalTimezoneScheduleRoute() {
+    return route()
+        .GET("/functional/schedule/timezone", req -> ServerResponse.ok().bodyValue("Allowed"))
+        .filter(endpointGateFilter.of("timezone-scheduled-gate"))
+        .build();
+  }
+
+  @Bean
+  RouterFunction<ServerResponse> functionalStableScheduleRoute() {
+    return route(
+        GET("/functional/schedule/stable"), req -> ServerResponse.ok().bodyValue("No Filter"));
+  }
+
+  public EndpointGateScheduleRouterConfiguration(
+      EndpointGateHandlerFilterFunction endpointGateFilter) {
+    this.endpointGateFilter = endpointGateFilter;
+  }
+}

--- a/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/filter/EndpointGateHandlerFilterFunction.java
+++ b/spring/webflux/src/main/java/net/brightroom/endpointgate/spring/webflux/filter/EndpointGateHandlerFilterFunction.java
@@ -119,14 +119,23 @@ public class EndpointGateHandlerFilterFunction {
    */
   public HandlerFilterFunction<ServerResponse, ServerResponse> of(
       String gateId, String conditionFallback, int rolloutFallback) {
-    if (gateId == null || gateId.isBlank()) {
+    if (gateId == null) {
       throw new IllegalArgumentException(
           "gateId must not be null or blank. "
               + "A blank value causes fail-open behavior and allows access unconditionally.");
     }
-    if (rolloutFallback < 0 || rolloutFallback > 100) {
+    if (gateId.isBlank()) {
       throw new IllegalArgumentException(
-          "rollout must be between 0 and 100, but was: " + rolloutFallback);
+          "gateId must not be null or blank. "
+              + "A blank value causes fail-open behavior and allows access unconditionally.");
+    }
+    if (rolloutFallback < 0) {
+      throw new IllegalArgumentException(
+          String.format("rollout must be between 0 and 100, but was: %d", rolloutFallback));
+    }
+    if (rolloutFallback > 100) {
+      throw new IllegalArgumentException(
+          String.format("rollout must be between 0 and 100, but was: %d", rolloutFallback));
     }
     return (request, next) ->
         Mono.zip(

--- a/spring/webmvc/src/integrationTest/java/net/brightroom/endpointgate/spring/webmvc/EndpointGateHandlerFilterFunctionScheduleIntegrationTest.java
+++ b/spring/webmvc/src/integrationTest/java/net/brightroom/endpointgate/spring/webmvc/EndpointGateHandlerFilterFunctionScheduleIntegrationTest.java
@@ -1,0 +1,110 @@
+package net.brightroom.endpointgate.spring.webmvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import net.brightroom.endpointgate.spring.webmvc.configuration.EndpointGateMvcTestAutoConfiguration;
+import net.brightroom.endpointgate.spring.webmvc.endpoint.EndpointGateScheduleRouterConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Verifies schedule-based endpoint gate control through the HandlerFilterFunction path:
+ *
+ * <ul>
+ *   <li>Property configuration → {@code InMemoryScheduleProvider} auto-wiring → filter → HTTP
+ *       response
+ *   <li>Active schedule (start in the past) → 200 OK
+ *   <li>Inactive schedule (start in the future) → 503 Service Unavailable + Retry-After header
+ *   <li>Inactive schedule (end only, no start) → 503 Service Unavailable, no Retry-After header
+ *   <li>Timezone-aware schedule → correctly evaluated in the configured timezone
+ * </ul>
+ */
+@WebMvcTest
+@Import({EndpointGateMvcTestAutoConfiguration.class, EndpointGateScheduleRouterConfiguration.class})
+@TestPropertySource(
+    properties = {
+      // active-scheduled-gate: start far in the past → always active
+      "endpoint-gate.gates.active-scheduled-gate.enabled=true",
+      "endpoint-gate.gates.active-scheduled-gate.schedule.start=2020-01-01T00:00:00",
+      // inactive-scheduled-gate: start far in the future → always inactive
+      "endpoint-gate.gates.inactive-scheduled-gate.enabled=true",
+      "endpoint-gate.gates.inactive-scheduled-gate.schedule.start=2099-01-01T00:00:00",
+      // end-only-inactive-scheduled-gate: end in the past, no start → inactive, no retry-after
+      "endpoint-gate.gates.end-only-inactive-scheduled-gate.enabled=true",
+      "endpoint-gate.gates.end-only-inactive-scheduled-gate.schedule.end=2020-01-01T00:00:00",
+      // timezone-scheduled-gate: start far in the past with timezone → always active
+      "endpoint-gate.gates.timezone-scheduled-gate.enabled=true",
+      "endpoint-gate.gates.timezone-scheduled-gate.schedule.start=2020-01-01T00:00:00",
+      "endpoint-gate.gates.timezone-scheduled-gate.schedule.timezone=Asia/Tokyo",
+    })
+class EndpointGateHandlerFilterFunctionScheduleIntegrationTest {
+
+  MockMvc mockMvc;
+
+  @Autowired
+  EndpointGateHandlerFilterFunctionScheduleIntegrationTest(MockMvc mockMvc) {
+    this.mockMvc = mockMvc;
+  }
+
+  @Test
+  void shouldAllowAccess_whenScheduleIsActive() throws Exception {
+    mockMvc
+        .perform(get("/functional/schedule/active"))
+        .andExpect(status().isOk())
+        .andExpect(content().string("Allowed"));
+  }
+
+  @Test
+  void shouldReturn503_whenScheduleIsInactive() throws Exception {
+    mockMvc
+        .perform(get("/functional/schedule/inactive"))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(
+            content()
+                .json(
+                    """
+                    {
+                      "status" : 503,
+                      "title" : "Endpoint gate temporarily unavailable",
+                      "type" : "https://github.com/bright-room/endpoint-gate#response-types"
+                    }
+                    """));
+  }
+
+  @Test
+  void shouldReturnRetryAfterHeader_whenScheduleIsInactive() throws Exception {
+    mockMvc
+        .perform(get("/functional/schedule/inactive"))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(header().exists("Retry-After"))
+        .andExpect(
+            header()
+                .string(
+                    "Retry-After",
+                    org.hamcrest.Matchers.matchesPattern(
+                        "\\w{3}, \\d{1,2} \\w{3} \\d{4} \\d{2}:\\d{2}:\\d{2} GMT")));
+  }
+
+  @Test
+  void shouldReturn503WithoutRetryAfter_whenEndOnlyScheduleIsInactive() throws Exception {
+    mockMvc
+        .perform(get("/functional/schedule/end-only-inactive"))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(header().doesNotExist("Retry-After"));
+  }
+
+  @Test
+  void shouldAllowAccess_whenScheduleIsActiveWithTimezone() throws Exception {
+    mockMvc
+        .perform(get("/functional/schedule/timezone"))
+        .andExpect(status().isOk())
+        .andExpect(content().string("Allowed"));
+  }
+}

--- a/spring/webmvc/src/integrationTest/java/net/brightroom/endpointgate/spring/webmvc/endpoint/EndpointGateScheduleRouterConfiguration.java
+++ b/spring/webmvc/src/integrationTest/java/net/brightroom/endpointgate/spring/webmvc/endpoint/EndpointGateScheduleRouterConfiguration.java
@@ -1,0 +1,58 @@
+package net.brightroom.endpointgate.spring.webmvc.endpoint;
+
+import static org.springframework.web.servlet.function.RequestPredicates.GET;
+import static org.springframework.web.servlet.function.RouterFunctions.route;
+
+import net.brightroom.endpointgate.spring.webmvc.filter.EndpointGateHandlerFilterFunction;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+@Configuration
+public class EndpointGateScheduleRouterConfiguration {
+
+  private final EndpointGateHandlerFilterFunction endpointGateFilter;
+
+  @Bean
+  RouterFunction<ServerResponse> functionalActiveScheduleRoute() {
+    return route()
+        .GET("/functional/schedule/active", req -> ServerResponse.ok().body("Allowed"))
+        .filter(endpointGateFilter.of("active-scheduled-gate"))
+        .build();
+  }
+
+  @Bean
+  RouterFunction<ServerResponse> functionalInactiveScheduleRoute() {
+    return route()
+        .GET("/functional/schedule/inactive", req -> ServerResponse.ok().body("Allowed"))
+        .filter(endpointGateFilter.of("inactive-scheduled-gate"))
+        .build();
+  }
+
+  @Bean
+  RouterFunction<ServerResponse> functionalEndOnlyInactiveScheduleRoute() {
+    return route()
+        .GET("/functional/schedule/end-only-inactive", req -> ServerResponse.ok().body("Allowed"))
+        .filter(endpointGateFilter.of("end-only-inactive-scheduled-gate"))
+        .build();
+  }
+
+  @Bean
+  RouterFunction<ServerResponse> functionalTimezoneScheduleRoute() {
+    return route()
+        .GET("/functional/schedule/timezone", req -> ServerResponse.ok().body("Allowed"))
+        .filter(endpointGateFilter.of("timezone-scheduled-gate"))
+        .build();
+  }
+
+  @Bean
+  RouterFunction<ServerResponse> functionalStableScheduleRoute() {
+    return route(GET("/functional/schedule/stable"), req -> ServerResponse.ok().body("No Filter"));
+  }
+
+  public EndpointGateScheduleRouterConfiguration(
+      EndpointGateHandlerFilterFunction endpointGateFilter) {
+    this.endpointGateFilter = endpointGateFilter;
+  }
+}

--- a/spring/webmvc/src/main/java/net/brightroom/endpointgate/spring/webmvc/filter/EndpointGateHandlerFilterFunction.java
+++ b/spring/webmvc/src/main/java/net/brightroom/endpointgate/spring/webmvc/filter/EndpointGateHandlerFilterFunction.java
@@ -118,14 +118,23 @@ public class EndpointGateHandlerFilterFunction {
    */
   public HandlerFilterFunction<ServerResponse, ServerResponse> of(
       String gateId, String conditionFallback, int rolloutFallback) {
-    if (gateId == null || gateId.isBlank()) {
+    if (gateId == null) {
       throw new IllegalArgumentException(
           "gateId must not be null or blank. "
               + "A blank value causes fail-open behavior and allows access unconditionally.");
     }
-    if (rolloutFallback < 0 || rolloutFallback > 100) {
+    if (gateId.isBlank()) {
       throw new IllegalArgumentException(
-          "rollout must be between 0 and 100, but was: " + rolloutFallback);
+          "gateId must not be null or blank. "
+              + "A blank value causes fail-open behavior and allows access unconditionally.");
+    }
+    if (rolloutFallback < 0) {
+      throw new IllegalArgumentException(
+          String.format("rollout must be between 0 and 100, but was: %d", rolloutFallback));
+    }
+    if (rolloutFallback > 100) {
+      throw new IllegalArgumentException(
+          String.format("rollout must be between 0 and 100, but was: %d", rolloutFallback));
     }
     return (request, next) -> {
       String condition = conditionProvider.getCondition(gateId).orElse(conditionFallback);


### PR DESCRIPTION
## Summary

- **H-1 (CG-7)**: Split `&&`/`||` compound conditions into separate `if` statements in `EndpointGateEndpoint`, `ReactiveEndpointGateEndpoint`, both `HandlerFilterFunction` implementations, and `ScheduleProperties`
- **H-2 (CG-9)**: Replace `+` string concatenation with `String.format()` in `ScheduleProperties`, `EndpointGateEndpoint`, `ReactiveEndpointGateEndpoint`, and both `HandlerFilterFunction` implementations
- **H-3 (CG-8)**: Extract `if/else if` schedule processing into `processScheduleUpdate()` helper method in both endpoint classes; also extract `validateGateId()`, `validateRollout()`, `updateCondition()`, and `resolveScheduleTimezone()` helpers
- **M-1 (CG-5)**: Break method chains into named variables in `ReactiveEndpointGateEndpoint.gate()`, `Schedule.isActive()`, and `EndpointGateEndpoint.buildScheduleResponse()`
- **M-2 (CG-6)**: Extract inline `if/else` condition handling into `updateCondition()` helper method in both endpoint classes
- **M-3**: Add `@Nullable` to `AccessDecision.denied()` 3-arg `retryAfter` parameter
- **M-4**: Add `HandlerFilterFunction` schedule integration tests for webmvc and webflux, verifying 503 + `Retry-After` behavior through the functional endpoint path
- **L-1**: Improve `EndpointGateScheduleInactiveException` constructor Javadoc from `Constructor.` to a descriptive summary sentence

## Test plan

- [x] `./gradlew :core:check` — passes
- [x] `./gradlew :spring:spring-core:check` — passes
- [x] `./gradlew :spring:spring-actuator:check` — passes
- [x] `./gradlew :spring:spring-webmvc:check` — passes (including new `EndpointGateHandlerFilterFunctionScheduleIntegrationTest`)
- [x] `./gradlew :spring:spring-webflux:check` — passes (including new `EndpointGateHandlerFilterFunctionScheduleIntegrationTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)