### PR TITLE
Close #57: Add WebFlux schedule example

### DIFF
--- a/examples/webflux/schedule/build.gradle.kts
+++ b/examples/webflux/schedule/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    id("example-base")
+    id("spotless-java")
+}
+
+dependencies {
+    implementation(project(":spring:spring-webflux"))
+    implementation(libs.spring.boot.starter.webflux)
+}

--- a/examples/webflux/schedule/src/main/java/net/brightroom/example/schedule/BusinessHoursController.java
+++ b/examples/webflux/schedule/src/main/java/net/brightroom/example/schedule/BusinessHoursController.java
@@ -1,0 +1,16 @@
+package net.brightroom.example.schedule;
+
+import net.brightroom.endpointgate.core.annotation.EndpointGate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+public class BusinessHoursController {
+
+  @EndpointGate("business-hours")
+  @GetMapping("/api/support/chat")
+  public Mono<String> supportChat() {
+    return Mono.just("Support chat is available");
+  }
+}

--- a/examples/webflux/schedule/src/main/java/net/brightroom/example/schedule/CampaignController.java
+++ b/examples/webflux/schedule/src/main/java/net/brightroom/example/schedule/CampaignController.java
@@ -1,0 +1,16 @@
+package net.brightroom.example.schedule;
+
+import net.brightroom.endpointgate.core.annotation.EndpointGate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+public class CampaignController {
+
+  @EndpointGate("campaign")
+  @GetMapping("/api/campaign/deals")
+  public Mono<String> campaignDeals() {
+    return Mono.just("Special campaign deals available");
+  }
+}

--- a/examples/webflux/schedule/src/main/java/net/brightroom/example/schedule/MaintenanceController.java
+++ b/examples/webflux/schedule/src/main/java/net/brightroom/example/schedule/MaintenanceController.java
@@ -1,0 +1,16 @@
+package net.brightroom.example.schedule;
+
+import net.brightroom.endpointgate.core.annotation.EndpointGate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+public class MaintenanceController {
+
+  @EndpointGate("maintenance-window")
+  @GetMapping("/api/maintenance/status")
+  public Mono<String> maintenanceStatus() {
+    return Mono.just("System is under maintenance");
+  }
+}

--- a/examples/webflux/schedule/src/main/java/net/brightroom/example/schedule/ScheduleExampleApplication.java
+++ b/examples/webflux/schedule/src/main/java/net/brightroom/example/schedule/ScheduleExampleApplication.java
@@ -1,0 +1,12 @@
+package net.brightroom.example.schedule;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ScheduleExampleApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(ScheduleExampleApplication.class, args);
+  }
+}

--- a/examples/webflux/schedule/src/main/resources/application.yml
+++ b/examples/webflux/schedule/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+endpoint-gate:
+  schedule:
+    default-timezone: Asia/Tokyo
+  gates:
+    maintenance-window:
+      enabled: true
+      schedule:
+        start: "2026-03-10T02:00:00"
+        end: "2026-03-10T06:00:00"
+    campaign:
+      enabled: true
+      schedule:
+        start: "2026-03-01T00:00:00"
+        end: "2026-03-31T23:59:59"
+        timezone: Asia/Tokyo
+    business-hours:
+      enabled: true
+      schedule:
+        start: "2026-01-01T09:00:00"
+        end: "2026-12-31T18:00:00"
+        timezone: America/New_York

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -56,4 +56,5 @@ include(
     "examples:webflux:basic-usage",
     "examples:webflux:functional-endpoint",
     "examples:webflux:rollout",
+    "examples:webflux:schedule",
 )


### PR DESCRIPTION
Close #57

Add `examples/webflux/schedule` module demonstrating schedule-based endpoint gate control in a WebFlux (reactive) environment.

## Changes

- `MaintenanceController`: maintenance window using global default timezone (Asia/Tokyo)
- `CampaignController`: campaign period control with gate-specific timezone
- `BusinessHoursController`: business hours control with gate-specific timezone (America/New_York)
- `application.yml`: schedule configuration including global default timezone
- `settings.gradle.kts`: added new module registration

Generated with [Claude Code](https://claude.ai/code)