### PR TITLE
Close #61: Add conditionFallback overloads to WebMVC functional-endpoint example

### DIFF
--- a/examples/webmvc/functional-endpoint/src/main/java/net/brightroom/example/functional/FeatureHandler.java
+++ b/examples/webmvc/functional-endpoint/src/main/java/net/brightroom/example/functional/FeatureHandler.java
@@ -18,4 +18,12 @@ public class FeatureHandler {
   public ServerResponse experimental(ServerRequest request) {
     return ServerResponse.ok().body("experimental-api: this endpoint is under development.");
   }
+
+  public ServerResponse internal(ServerRequest request) {
+    return ServerResponse.ok().body("internal-api: internal data accessible to internal clients.");
+  }
+
+  public ServerResponse preview(ServerRequest request) {
+    return ServerResponse.ok().body("preview-feature: preview feature for early adopters.");
+  }
 }

--- a/examples/webmvc/functional-endpoint/src/main/java/net/brightroom/example/functional/RoutingConfiguration.java
+++ b/examples/webmvc/functional-endpoint/src/main/java/net/brightroom/example/functional/RoutingConfiguration.java
@@ -40,4 +40,20 @@ public class RoutingConfiguration {
         .filter(endpointGateFilter.of("experimental-api"))
         .build();
   }
+
+  @Bean
+  RouterFunction<ServerResponse> internalRoute(FeatureHandler handler) {
+    return route()
+        .GET("/api/internal", handler::internal)
+        .filter(endpointGateFilter.of("internal-api", "headers['X-Internal'] == 'true'"))
+        .build();
+  }
+
+  @Bean
+  RouterFunction<ServerResponse> previewRoute(FeatureHandler handler) {
+    return route()
+        .GET("/api/preview", handler::preview)
+        .filter(endpointGateFilter.of("preview-feature", "params['preview'] == 'true'", 30))
+        .build();
+  }
 }

--- a/examples/webmvc/functional-endpoint/src/main/resources/application.yml
+++ b/examples/webmvc/functional-endpoint/src/main/resources/application.yml
@@ -7,3 +7,7 @@ endpoint-gate:
       rollout: 50
     experimental-api:
       enabled: false
+    internal-api:
+      enabled: true
+    preview-feature:
+      enabled: true


### PR DESCRIPTION
Closes #61

Add usage examples for the missing `EndpointGateHandlerFilterFunction.of()` overloads:
- `of(gateId, conditionFallback)`: `/api/internal` route using `X-Internal` header as fallback condition
- `of(gateId, conditionFallback, rolloutFallback)`: `/api/preview` route with `preview` param condition and 30% rollout fallback

Generated with [Claude Code](https://claude.ai/code)