### PR TITLE
Close #62: Add conditionFallback overloads to WebFlux functional-endpoint example

### DIFF
--- a/examples/webflux/functional-endpoint/src/main/java/net/brightroom/example/functional/FeatureHandler.java
+++ b/examples/webflux/functional-endpoint/src/main/java/net/brightroom/example/functional/FeatureHandler.java
@@ -19,4 +19,12 @@ public class FeatureHandler {
   public Mono<ServerResponse> experimental(ServerRequest request) {
     return ServerResponse.ok().bodyValue("experimental-api: this endpoint is under development.");
   }
+
+  public Mono<ServerResponse> internal(ServerRequest request) {
+    return ServerResponse.ok().bodyValue("internal-api: this endpoint is for internal use only.");
+  }
+
+  public Mono<ServerResponse> preview(ServerRequest request) {
+    return ServerResponse.ok().bodyValue("preview-feature: you are in the preview group!");
+  }
 }

--- a/examples/webflux/functional-endpoint/src/main/java/net/brightroom/example/functional/RoutingConfiguration.java
+++ b/examples/webflux/functional-endpoint/src/main/java/net/brightroom/example/functional/RoutingConfiguration.java
@@ -40,4 +40,20 @@ public class RoutingConfiguration {
         .filter(endpointGateFilter.of("experimental-api"))
         .build();
   }
+
+  @Bean
+  RouterFunction<ServerResponse> internalRoute(FeatureHandler handler) {
+    return route()
+        .GET("/api/internal", handler::internal)
+        .filter(endpointGateFilter.of("internal-api", "headers['X-Internal'] == 'true'"))
+        .build();
+  }
+
+  @Bean
+  RouterFunction<ServerResponse> previewRoute(FeatureHandler handler) {
+    return route()
+        .GET("/api/preview", handler::preview)
+        .filter(endpointGateFilter.of("preview-feature", "params['preview'] == 'true'", 30))
+        .build();
+  }
 }

--- a/examples/webflux/functional-endpoint/src/main/resources/application.yml
+++ b/examples/webflux/functional-endpoint/src/main/resources/application.yml
@@ -7,3 +7,7 @@ endpoint-gate:
       rollout: 50
     experimental-api:
       enabled: false
+    internal-api:
+      enabled: true
+    preview-feature:
+      enabled: true


### PR DESCRIPTION
Close #62

## Changes

Add missing `EndpointGateHandlerFilterFunction.of()` overload examples to the WebFlux functional-endpoint example:

- `of(gateId, conditionFallback)`: `/api/internal` route guarded by `X-Internal: true` header condition
- `of(gateId, conditionFallback, rolloutFallback)`: `/api/preview` route with `preview=true` query parameter condition and 30% rollout

Generated with [Claude Code](https://claude.ai/code)