### PR TITLE
Close #63: Add EndpointGateScheduleChangedEvent to WebMVC event-listener example

### DIFF
--- a/examples/webmvc/event-listener/src/main/java/net/brightroom/example/eventlistener/AuditEventListener.java
+++ b/examples/webmvc/event-listener/src/main/java/net/brightroom/example/eventlistener/AuditEventListener.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import net.brightroom.endpointgate.spring.core.event.EndpointGateChangedEvent;
 import net.brightroom.endpointgate.spring.core.event.EndpointGateRemovedEvent;
+import net.brightroom.endpointgate.spring.core.event.EndpointGateScheduleChangedEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.event.EventListener;
@@ -30,6 +31,16 @@ public class AuditEventListener {
   @EventListener
   public void onRemoved(EndpointGateRemovedEvent event) {
     String entry = String.format("[%s] REMOVED: gate=%s", Instant.now(), event.gateId());
+    auditLog.add(entry);
+    log.info(entry);
+  }
+
+  @EventListener
+  public void onScheduleChanged(EndpointGateScheduleChangedEvent event) {
+    String entry =
+        String.format(
+            "[%s] Schedule changed: id=%s, schedule=%s",
+            Instant.now(), event.gateId(), event.schedule());
     auditLog.add(entry);
     log.info(entry);
   }

--- a/examples/webmvc/event-listener/src/main/java/net/brightroom/example/eventlistener/CacheInvalidationListener.java
+++ b/examples/webmvc/event-listener/src/main/java/net/brightroom/example/eventlistener/CacheInvalidationListener.java
@@ -2,6 +2,7 @@ package net.brightroom.example.eventlistener;
 
 import net.brightroom.endpointgate.spring.core.event.EndpointGateChangedEvent;
 import net.brightroom.endpointgate.spring.core.event.EndpointGateRemovedEvent;
+import net.brightroom.endpointgate.spring.core.event.EndpointGateScheduleChangedEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.event.EventListener;
@@ -28,5 +29,11 @@ public class CacheInvalidationListener {
   public void onRemoved(EndpointGateRemovedEvent event) {
     log.info("Invalidating cache for removed gate: {}", event.gateId());
     cache.invalidate(event.gateId());
+  }
+
+  @EventListener
+  public void onScheduleChanged(EndpointGateScheduleChangedEvent event) {
+    cache.invalidate(event.gateId());
+    log.info("Cache evicted for schedule change: {}", event.gateId());
   }
 }


### PR DESCRIPTION
Close #63

Add `EndpointGateScheduleChangedEvent` handlers to `AuditEventListener` and `CacheInvalidationListener` in the `examples/webmvc/event-listener` module.

Generated with [Claude Code](https://claude.ai/code)