### PR TITLE
Close #66: Add functional endpoint custom error handling to WebMVC error-handling example

### DIFF
--- a/examples/webmvc/error-handling/src/main/java/net/brightroom/example/errorhandling/CustomAccessDeniedHandlerFilterResolution.java
+++ b/examples/webmvc/error-handling/src/main/java/net/brightroom/example/errorhandling/CustomAccessDeniedHandlerFilterResolution.java
@@ -1,0 +1,33 @@
+package net.brightroom.example.errorhandling;
+
+import net.brightroom.endpointgate.core.exception.EndpointGateAccessDeniedException;
+import net.brightroom.endpointgate.spring.webmvc.resolution.handlerfilter.AccessDeniedHandlerFilterResolution;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.function.ServerRequest;
+import org.springframework.web.servlet.function.ServerResponse;
+
+/**
+ * C-3: Custom AccessDeniedHandlerFilterResolution for Functional Endpoint path.
+ *
+ * <p>Replaces the default bean via @ConditionalOnMissingBean. Returns a custom JSON error response
+ * when an endpoint gate denies access through functional endpoints.
+ */
+@Component
+@Profile("functional-error")
+public class CustomAccessDeniedHandlerFilterResolution
+    implements AccessDeniedHandlerFilterResolution {
+
+  @Override
+  public ServerResponse resolve(ServerRequest request, EndpointGateAccessDeniedException e) {
+    String body =
+        String.format(
+            "{\"error\":\"access_denied\",\"gate\":\"%s\",\"path\":\"%s\"}",
+            e.gateId(), request.path());
+    ServerResponse.BodyBuilder builder =
+        ServerResponse.status(HttpStatus.FORBIDDEN).contentType(MediaType.APPLICATION_JSON);
+    return builder.body(body);
+  }
+}

--- a/examples/webmvc/error-handling/src/main/java/net/brightroom/example/errorhandling/ErrorHandlingHandler.java
+++ b/examples/webmvc/error-handling/src/main/java/net/brightroom/example/errorhandling/ErrorHandlingHandler.java
@@ -1,0 +1,22 @@
+package net.brightroom.example.errorhandling;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.function.ServerRequest;
+import org.springframework.web.servlet.function.ServerResponse;
+
+/** Handler for functional endpoint requests. */
+@Component
+@Profile("functional-error")
+public class ErrorHandlingHandler {
+
+  /**
+   * Handles the gated endpoint request.
+   *
+   * @param request the server request
+   * @return the server response
+   */
+  public ServerResponse gated(ServerRequest request) {
+    return ServerResponse.ok().body("Functional endpoint data");
+  }
+}

--- a/examples/webmvc/error-handling/src/main/java/net/brightroom/example/errorhandling/ErrorHandlingRouter.java
+++ b/examples/webmvc/error-handling/src/main/java/net/brightroom/example/errorhandling/ErrorHandlingRouter.java
@@ -1,0 +1,37 @@
+package net.brightroom.example.errorhandling;
+
+import net.brightroom.endpointgate.spring.webmvc.filter.EndpointGateHandlerFilterFunction;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.RouterFunctions;
+import org.springframework.web.servlet.function.ServerResponse;
+
+/**
+ * Functional endpoint routing configuration demonstrating custom
+ * AccessDeniedHandlerFilterResolution.
+ *
+ * <p>When the endpoint gate is disabled, the custom resolution bean provides the denied response
+ * instead of the default. Note: @ControllerAdvice is NOT used for functional endpoints.
+ */
+@Configuration
+@Profile("functional-error")
+public class ErrorHandlingRouter {
+
+  /**
+   * Registers functional endpoint routes with endpoint gate filter.
+   *
+   * @param handler the request handler
+   * @param endpointGateFilter the endpoint gate filter function factory
+   * @return the router function
+   */
+  @Bean
+  public RouterFunction<ServerResponse> errorHandlingRoutes(
+      ErrorHandlingHandler handler, EndpointGateHandlerFilterFunction endpointGateFilter) {
+    return RouterFunctions.route()
+        .GET("/api/functional/gated", handler::gated)
+        .filter(endpointGateFilter.of("functional-gated"))
+        .build();
+  }
+}

--- a/examples/webmvc/error-handling/src/main/resources/application-functional-error.yml
+++ b/examples/webmvc/error-handling/src/main/resources/application-functional-error.yml
@@ -1,0 +1,4 @@
+endpoint-gate:
+  gates:
+    functional-gated:
+      enabled: false


### PR DESCRIPTION
Close #66

Add `AccessDeniedHandlerFilterResolution` custom implementation, functional endpoint router and handler, and `application-functional-error.yml` profile configuration to `examples/webmvc/error-handling`.

Generated with [Claude Code](https://claude.ai/code)