### PR TITLE
Close #67: Add HealthDetailsContributor demo to WebMVC health-indicator example

### DIFF
--- a/examples/webmvc/health-indicator/src/main/java/net/brightroom/example/health/CustomHealthDetailsContributor.java
+++ b/examples/webmvc/health-indicator/src/main/java/net/brightroom/example/health/CustomHealthDetailsContributor.java
@@ -1,0 +1,19 @@
+package net.brightroom.example.health;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import net.brightroom.endpointgate.spring.actuator.health.HealthDetailsContributor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomHealthDetailsContributor implements HealthDetailsContributor {
+
+  @Override
+  public Map<String, Object> contributeDetails() {
+    Map<String, Object> details = new LinkedHashMap<>();
+    details.put("environment", "production");
+    details.put("lastChecked", Instant.now().toString());
+    return details;
+  }
+}


### PR DESCRIPTION
Close #67

Adds `CustomHealthDetailsContributor` implementation to the `examples/webmvc/health-indicator` example. The contributor demonstrates how to extend the health response with custom details such as environment name and last checked timestamp.

Generated with [Claude Code](https://claude.ai/code)