### PR TITLE
Close #68: Add ReactiveHealthDetailsContributor demo to WebFlux health-indicator example

### DIFF
--- a/examples/webflux/health-indicator/src/main/java/net/brightroom/example/healthindicator/CustomReactiveHealthDetailsContributor.java
+++ b/examples/webflux/health-indicator/src/main/java/net/brightroom/example/healthindicator/CustomReactiveHealthDetailsContributor.java
@@ -1,0 +1,17 @@
+package net.brightroom.example.healthindicator;
+
+import java.time.Instant;
+import java.util.Map;
+import net.brightroom.endpointgate.spring.actuator.health.ReactiveHealthDetailsContributor;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+public class CustomReactiveHealthDetailsContributor implements ReactiveHealthDetailsContributor {
+
+  @Override
+  public Mono<Map<String, Object>> contributeDetails() {
+    return Mono.fromCallable(
+        () -> Map.of("environment", "production", "lastChecked", Instant.now().toString()));
+  }
+}


### PR DESCRIPTION
Close #68

Adds `CustomReactiveHealthDetailsContributor` to the WebFlux health-indicator example, demonstrating how to implement the `ReactiveHealthDetailsContributor` extension point to add custom details to the health response reactively.

Generated with [Claude Code](https://claude.ai/code)