### PR TITLE
ci: add Javadoc doclint check to PR workflow

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -17,8 +17,21 @@ jobs:
         with:
           command: spotlessCheck
 
+  javadoc:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Javadoc Check
+        uses: ./.github/actions/gradle-action
+        with:
+          command: javadoc
+
   unit-test:
-    needs: lint
+    needs: [lint, javadoc]
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -32,7 +45,7 @@ jobs:
           command: test
 
   integration-test:
-    needs: lint
+    needs: [lint, javadoc]
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -44,17 +57,3 @@ jobs:
         uses: ./.github/actions/gradle-action
         with:
           command: integrationTest
-
-  javadoc:
-    needs: lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v6
-
-      - name: Javadoc Check
-        uses: ./.github/actions/gradle-action
-        with:
-          command: javadoc

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -44,3 +44,17 @@ jobs:
         uses: ./.github/actions/gradle-action
         with:
           command: integrationTest
+
+  javadoc:
+    needs: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Javadoc Check
+        uses: ./.github/actions/gradle-action
+        with:
+          command: javadoc

--- a/gradle-scripts/src/main/kotlin/java-conventions.gradle.kts
+++ b/gradle-scripts/src/main/kotlin/java-conventions.gradle.kts
@@ -26,4 +26,9 @@ tasks {
         useJUnitPlatform()
         maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
     }
+
+    javadoc {
+        (options as StandardJavadocDocletOptions).addStringOption("Xdoclint:all", "-quiet")
+        isFailOnError = true
+    }
 }


### PR DESCRIPTION
## Summary
- `java-conventions` プラグインの `javadoc` タスクに `-Xdoclint:all` と `isFailOnError = true` を追加し、Javadoc の記述漏れをビルドエラーとして検出
- `on-pull-request` ワークフローに `javadoc` ジョブを追加し、PR 段階で Javadoc エラーを検出可能に
- Maven Central アップロード時に初めて Javadoc エラーが発覚する問題を防止

## Test plan
- [ ] `./gradlew javadoc` がライブラリモジュールで正常に通ること
- [ ] Javadoc 記述漏れを意図的に追加した場合にビルドが失敗すること
- [ ] PR ワークフローで `javadoc` ジョブが実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)